### PR TITLE
perf(web): cache hashed assets immutably

### DIFF
--- a/web/public/_headers
+++ b/web/public/_headers
@@ -4,3 +4,6 @@
   X-Frame-Options: SAMEORIGIN
   Strict-Transport-Security: max-age=31536000; includeSubDomains
   Permissions-Policy: geolocation=(), microphone=(), camera=(self)
+
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable


### PR DESCRIPTION
## What & why

Content-hashed Vite bundles are immutable, but Cloudflare Pages currently
serves them with `max-age=0, must-revalidate`. This adds a path-scoped
`Cache-Control` rule for `/assets/*` while leaving the HTML shell and other
non-hashed public files on their existing revalidation behavior.

Closes #47

## Type

- [ ] feat
- [ ] fix
- [x] docs / chore / refactor / test / perf

## Checklist

- [x] `pnpm lint && pnpm typecheck` pass locally
- [x] `pnpm --filter @warp/web build` is green

The production build copies the rule to `web/dist/_headers`:

```text
/assets/*
  Cache-Control: public, max-age=31536000, immutable
```

Existing lint output contains 7 warnings and 0 errors in unrelated files.

### Hard constraints

- [x] No new recurring-cost infrastructure
- [x] Still STUN-only
- [x] Signaling server behavior is unchanged
- [x] `SEND_HIGH_WATER` is untouched
- [x] Transfer recovery behavior is unchanged

## Screenshots / recordings

Not applicable. This is a static Cloudflare Pages header rule with no UI or
runtime application-code changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved loading efficiency for static assets by enabling long-term browser caching.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->