### PR TITLE
fix(transfer): promote formatBytes past 1000-unit boundaries

### DIFF
--- a/web/src/lib/warp/transfer.check.mjs
+++ b/web/src/lib/warp/transfer.check.mjs
@@ -29,7 +29,7 @@ try {
   process.exit(0);
 }
 
-const { fileKey, newResumeToken } = mod;
+const { fileKey, newResumeToken, formatBytes } = mod;
 
 // --- fileKey: stable per (name,size,mtime); changes when any of them changes ---
 const a = { name: "clip.mp4", size: 1234, lastModified: 42 };
@@ -49,4 +49,15 @@ const t2 = newResumeToken();
 assert.ok(/^[a-z0-9]{10,}$/.test(t1), "token is a non-trivial lowercase-alnum id");
 assert.notEqual(t1, t2, "tokens are unique per call");
 
-console.log("OK: transfer.ts resume identity helpers (fileKey stability + token uniqueness)");
+// --- formatBytes: never show 1000 of a smaller unit at boundaries ---
+assert.equal(formatBytes(999), "999 B", "bytes stay in B below 1 KB");
+assert.equal(formatBytes(1000), "1 KB", "exact KB boundary");
+assert.equal(formatBytes(999_499), "999 KB", "just under rounded KB→MB boundary");
+assert.equal(formatBytes(999_950), "1.0 MB", "999_950 must not render as 1000 KB");
+assert.equal(formatBytes(999_999), "1.0 MB", "999_999 must not render as 1000 KB");
+assert.equal(formatBytes(1_400_000), "1.4 MB", "ordinary MB with one decimal");
+assert.equal(formatBytes(120_000_000), "120 MB", "large MB uses zero decimals");
+assert.equal(formatBytes(999_999_999), "1.0 GB", "999_999_999 must not render as 1000 MB");
+assert.equal(formatBytes(1_000_000_000), "1.0 GB", "exact GB boundary");
+
+console.log("OK: transfer.ts resume identity helpers (fileKey stability + token uniqueness) + formatBytes boundaries");

--- a/web/src/lib/warp/transfer.ts
+++ b/web/src/lib/warp/transfer.ts
@@ -128,8 +128,22 @@ export interface TransferItem {
 /** Human-readable byte formatter matching the design's `fmt()`. */
 export function formatBytes(b: number): string {
   if (b >= 1e9) return (b / 1e9).toFixed(1) + " GB";
-  if (b >= 1e6) return (b / 1e6).toFixed(b >= 1e8 ? 0 : 1) + " MB";
-  if (b >= 1e3) return (b / 1e3).toFixed(0) + " KB";
+
+  if (b >= 1e6) {
+    const decimals = b >= 1e8 ? 0 : 1;
+    const mb = Number((b / 1e6).toFixed(decimals));
+    // Rounding can push just-under-1GB sizes to "1000 MB" — promote to GB.
+    if (mb >= 1000) return (b / 1e9).toFixed(1) + " GB";
+    return mb.toFixed(decimals) + " MB";
+  }
+
+  if (b >= 1e3) {
+    const kb = Math.round(b / 1e3);
+    // Rounding can push just-under-1MB sizes to "1000 KB" — promote to MB.
+    if (kb >= 1000) return (b / 1e6).toFixed(1) + " MB";
+    return kb + " KB";
+  }
+
   return b + " B";
 }
 


### PR DESCRIPTION
﻿## Summary
- Fix `formatBytes` so sizes just under 1 MB / 1 GB promote to the next unit instead of showing `1000 KB` / `1000 MB`.
- Add boundary asserts in `transfer.check.mjs` for B/KB, KB/MB, and MB/GB.

Fixes #64

## Test plan
- [x] `node src/lib/warp/transfer.check.mjs` from `web/` (with esbuild)
- [ ] Spot-check transfer UI size labels near 1 MB and 1 GB


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file size formatting across bytes, kilobytes, megabytes, and gigabytes.
  * Prevented near-boundary values from displaying as misleading “1000 KB” or “1000 MB”; values now promote to the next appropriate unit.

* **Tests**
  * Added coverage for unit-boundary formatting, including exact and near-boundary values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->