### PR TITLE
fix(web): honor VITE_SIGNALING_URL for signaling

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ pnpm dev:server   # signaling server (wrangler dev, local workerd) on :8787
 pnpm dev          # web app (vite) on :5173
 ```
 
-Open `http://localhost:5173` in **two browser tabs** (or two devices on your LAN) to try a transfer end-to-end. The deployed frontend talks to the live signaling server, so the web app works standalone too — you only need `pnpm dev:server` when changing the server.
+Open `http://localhost:5173` in **two browser tabs** (or two devices on your LAN) to try a transfer end-to-end. By default the web app talks to the live signaling server. To point it at your local `pnpm dev:server` instead, copy [`web/.env.example`](./web/.env.example) to `web/.env` (or set `VITE_SIGNALING_URL=ws://localhost:8787`) and restart `pnpm dev` — Vite inlines `import.meta.env` at startup.
 
 ### Checks — run these before every PR
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ pnpm --filter @warp/server test   # signaling e2e
   pnpm --filter @warp/server run deploy
   ```
 
-Point `VITE_SIGNALING_URL` in the frontend at your signaling server's `wss://` URL.
+Point `VITE_SIGNALING_URL` in the frontend at your signaling server's `wss://` URL (see [`web/.env.example`](./web/.env.example)). Vite inlines it at build time — rebuild after changing it.
 
 ## Architecture & protocol
 

--- a/web/src/lib/warp/signaling.ts
+++ b/web/src/lib/warp/signaling.ts
@@ -19,7 +19,8 @@
  *   { type: 'error', error }                  server-side failure
  */
 
-const SIGNALING_URL = "wss://warp-signaling.ishannaik7.workers.dev";
+const SIGNALING_URL =
+  import.meta.env.VITE_SIGNALING_URL ?? "wss://warp-signaling.ishannaik7.workers.dev";
 
 /**
  * Opaque WebRTC handshake payload (SDP offer/answer or ICE candidate), PLUS an

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_SIGNALING_URL?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary
- `signaling.ts` now uses `import.meta.env.VITE_SIGNALING_URL` with the existing production `wss://` URL as the default.
- Adds `web/src/vite-env.d.ts` typing and documents local override via `web/.env.example` in README + CONTRIBUTING.
- Fixes #13

## Test plan
- [ ] Unset env → app still talks to `wss://warp-signaling.ishannaik7.workers.dev`
- [ ] `VITE_SIGNALING_URL=ws://localhost:8787 pnpm dev` with `pnpm dev:server` connects room + nearby flows
- [ ] `pnpm lint && pnpm typecheck && pnpm --filter @warp/web build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring the signaling server URL through the frontend environment configuration.
  * The app continues using the default signaling server when no custom URL is provided.

* **Documentation**
  * Updated local development instructions for connecting to a locally running signaling server.
  * Clarified that frontend configuration changes require rebuilding the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->