### PR TITLE
fix: add styled noscript message for JavaScript-disabled users

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -66,6 +66,35 @@
   </head>
   <body>
     <div id="root"></div>
+    <noscript>
+      <div
+        style="
+          position: fixed;
+          inset: 0;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          padding: 24px;
+          background: #121110;
+          color: #a8a293;
+          font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+          text-align: center;
+        "
+      >
+        <div style="max-width: 360px;">
+          <p style="color: #efe9da; font-size: 1.1rem; font-weight: 600; margin: 0 0 8px;">
+            Warp needs JavaScript
+          </p>
+          <p style="margin: 0 0 12px; line-height: 1.5;">
+            Warp uses JavaScript for peer-to-peer file transfers. Please enable
+            JavaScript, or disable any script-blocking extensions, to continue.
+          </p>
+          <a href="https://github.com/Ishannaik/warp" style="color: #efe9da;">
+            View on GitHub
+          </a>
+        </div>
+      </div>
+    </noscript>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>


### PR DESCRIPTION
Added a styled <noscript> block in web/index.html, right after the #root div. Previously, users with JavaScript disabled (or a script-blocking extension) saw a fully blank dark page with no explanation.

The message uses the app's existing design tokens (#121110 background, #efe9da heading, #a8a293 body text), explains that Warp needs JavaScript for peer-to-peer transfers, and links to the GitHub repo.

Verified: pnpm lint, pnpm typecheck, and pnpm --filter @warp/web build all pass. Manually tested with JavaScript disabled at 360px width — message renders centered with no horizontal overflow.

Closes #65

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a fallback message for visitors with JavaScript disabled, explaining how to enable required functionality.
  * Included guidance for disabling script-blocking extensions and a link to the project repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->