### PR TITLE
fix(transfer): remove unused generateCode helper

### DIFF
--- a/web/src/lib/warp/transfer.ts
+++ b/web/src/lib/warp/transfer.ts
@@ -133,14 +133,6 @@ export function formatBytes(b: number): string {
   return b + " B";
 }
 
-/** Crockford-ish room code: WRAP-XXXX-XX. */
-export function generateCode(): string {
-  const alphabet = "0123456789ABCDEFGHJKLMNPQRSTUVWXYZ";
-  const pick = (n: number) =>
-    Array.from({ length: n }, () => alphabet[Math.floor(Math.random() * alphabet.length)]).join("");
-  return `WRAP-${pick(4)}-${pick(2)}`;
-}
-
 /** Stable id for a file or batch. */
 export function fileId(): string {
   return Math.random().toString(36).slice(2, 10);


### PR DESCRIPTION
## Summary
- Deletes the dead client-side `generateCode()` helper from `transfer.ts` (room codes are server-minted).
- Fixes #63

## Test plan
- [ ] `git grep -n generateCode -- web` returns no matches
- [ ] `pnpm --filter @warp/web build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the unused room-code generation functionality.
  * File transfer formatting and identification features remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->