### PR TITLE
chore(transfer): remove dead client code generator

### DIFF
--- a/web/src/lib/warp/transfer.ts
+++ b/web/src/lib/warp/transfer.ts
@@ -133,14 +133,6 @@ export function formatBytes(b: number): string {
   return b + " B";
 }
 
-/** Crockford-ish room code: WRAP-XXXX-XX. */
-export function generateCode(): string {
-  const alphabet = "0123456789ABCDEFGHJKLMNPQRSTUVWXYZ";
-  const pick = (n: number) =>
-    Array.from({ length: n }, () => alphabet[Math.floor(Math.random() * alphabet.length)]).join("");
-  return `WRAP-${pick(4)}-${pick(2)}`;
-}
-
 /** Stable id for a file or batch. */
 export function fileId(): string {
   return Math.random().toString(36).slice(2, 10);


### PR DESCRIPTION
## Summary

- Remove the unused client-side `generateCode()` helper from `web/src/lib/warp/transfer.ts`.
- Leave room-code generation server-owned; no replacement client generator added.

Closes #63

## Verification

- `git grep -n generateCode -- web` (no matches)
- `git diff --check`
- `cd web && node src/lib/warp/transfer.check.mjs`
- `npx --yes pnpm@10.27.0 --filter @warp/web lint` (passes with existing warnings)
- `npx --yes pnpm@10.27.0 --filter @warp/web typecheck`
- `npx --yes pnpm@10.27.0 --filter @warp/web build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the unused room-code generation utility.
  * File transfer functionality and related utilities remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->