### PR TITLE
fix(web): show a 404 page for unknown routes

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6,6 +6,7 @@ import Theory from "./theory/Theory";
 import ReceiveEntry from "./receive/ReceiveEntry";
 import BrandKit from "./brand/BrandKit";
 import Legal from "./legal/Legal";
+import NotFound from "./NotFound";
 import { useRoute } from "./router";
 import { useDocumentSeo } from "./lib/useDocumentSeo";
 
@@ -52,6 +53,12 @@ function seoForRoute(path: string): { title: string; description: string } {
         "How Warp handles your data — short version: your files never touch a server.",
     };
   }
+  if (path !== "/") {
+    return {
+      title: "Page not found · Warp",
+      description: "This Warp URL doesn’t match a known page.",
+    };
+  }
   return {
     title: "Warp — Send files directly between devices",
     description:
@@ -65,6 +72,7 @@ export default function App() {
   const { title, description } = seoForRoute(path);
   useDocumentSeo(title, description);
 
+  if (path === "/") return <Landing />;
   if (path === "/send") return <TransferFlow />;
   if (path === "/receive") return <ReceiveEntry />;
   if (path.startsWith("/r/") && code) return <TransferFlow joinCode={code} />;
@@ -73,5 +81,5 @@ export default function App() {
   if (path === "/terms") return <Legal kind="terms" />;
   if (path === "/privacy") return <Legal kind="privacy" />;
 
-  return <Landing />;
+  return <NotFound />;
 }

--- a/web/src/NotFound.tsx
+++ b/web/src/NotFound.tsx
@@ -1,0 +1,179 @@
+import { navigate } from "./router";
+import WarpLogo from "./WarpLogo";
+import { useIsMobile } from "./lib/useIsMobile";
+
+/**
+ * NotFound — unmatched routes. Keeps the receive-page chrome (dark grid, mono
+ * labels, wordmark) so a typo'd URL doesn't silently look like the homepage.
+ */
+
+const MONO = "'JetBrains Mono',monospace";
+const DISPLAY = "'Bricolage Grotesque',sans-serif";
+const HAIR = "rgba(239,233,218,.14)";
+
+export default function NotFound() {
+  const isMobile = useIsMobile();
+
+  const link = (href: string, label: string) => (
+    <a
+      href={href}
+      className="nf-link"
+      onClick={(e) => {
+        e.preventDefault();
+        navigate(href);
+      }}
+      style={{
+        display: isMobile ? "block" : "inline-block",
+        padding: "13px 20px",
+        border: "1px solid rgba(239,233,218,.22)",
+        color: "#a8a293",
+        fontFamily: MONO,
+        fontSize: "12px",
+        letterSpacing: ".07em",
+        textTransform: "uppercase",
+        textDecoration: "none",
+        textAlign: "center",
+        background: "rgba(239,233,218,.03)",
+        boxSizing: "border-box",
+      }}
+    >
+      {label}
+    </a>
+  );
+
+  return (
+    <div
+      style={{
+        position: "relative",
+        minHeight: "100vh",
+        display: "flex",
+        flexDirection: "column",
+        fontFamily: "'Archivo',system-ui,sans-serif",
+        color: "#efe9da",
+        overflowX: "hidden",
+        background:
+          "repeating-linear-gradient(0deg,transparent 0,transparent 31px,rgba(239,233,218,.035) 31px,rgba(239,233,218,.035) 32px),repeating-linear-gradient(90deg,transparent 0,transparent 31px,rgba(239,233,218,.035) 31px,rgba(239,233,218,.035) 32px),#121110",
+      }}
+    >
+      <style>{`
+        .nf-link:hover{border-color:var(--acc);color:#efe9da}
+        .nf-back:hover{color:#efe9da}
+      `}</style>
+
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          padding: isMobile ? "14px 16px" : "18px 26px",
+          borderBottom: `1px solid ${HAIR}`,
+        }}
+      >
+        <a
+          href="/"
+          onClick={(e) => {
+            e.preventDefault();
+            navigate("/");
+          }}
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: "11px",
+            textDecoration: "none",
+            color: "#efe9da",
+          }}
+        >
+          <WarpLogo size={24} />
+          <span
+            style={{
+              fontFamily: DISPLAY,
+              fontSize: "19px",
+              fontWeight: 800,
+              letterSpacing: "-.02em",
+            }}
+          >
+            WARP
+          </span>
+        </a>
+
+        <a
+          href="/"
+          className="nf-back"
+          onClick={(e) => {
+            e.preventDefault();
+            navigate("/");
+          }}
+          style={{
+            fontFamily: MONO,
+            fontSize: "12px",
+            letterSpacing: ".06em",
+            color: "#908a7b",
+            textDecoration: "none",
+          }}
+        >
+          ← HOME
+        </a>
+      </div>
+
+      <div
+        style={{
+          flex: 1,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          padding: isMobile ? "32px 16px" : "48px 26px",
+        }}
+      >
+        <div style={{ width: "100%", maxWidth: "460px", animation: "warpFade .5s ease both" }}>
+          <div
+            style={{
+              fontFamily: MONO,
+              fontSize: "11.5px",
+              letterSpacing: ".2em",
+              textTransform: "uppercase",
+              color: "#6f6a5d",
+              marginBottom: "12px",
+            }}
+          >
+            404 · page not found
+          </div>
+          <h1
+            style={{
+              fontFamily: DISPLAY,
+              fontWeight: 700,
+              fontSize: isMobile ? "clamp(32px,9vw,44px)" : "clamp(36px,5vw,52px)",
+              lineHeight: 1,
+              letterSpacing: "-.03em",
+              margin: "0 0 16px",
+            }}
+          >
+            This page doesn’t exist
+          </h1>
+          <p
+            style={{
+              fontSize: "15.5px",
+              lineHeight: 1.55,
+              color: "#a8a293",
+              margin: "0 0 30px",
+            }}
+          >
+            The link may be mistyped. Head home, or open a send / receive channel.
+          </p>
+
+          <div
+            style={{
+              display: "flex",
+              flexDirection: isMobile ? "column" : "row",
+              flexWrap: "wrap",
+              gap: "12px",
+            }}
+          >
+            {link("/", "← Home")}
+            {link("/send", "Send a file")}
+            {link("/receive", "Receive a file")}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Unmatched paths render a new `NotFound` page instead of silently falling through to `Landing`.
- `/` still shows the landing page; known routes are unchanged.
- SEO title `Page not found · Warp` for unknown paths.
- Fixes #66

## Test plan
- [ ] `/nope` shows the 404 page with Home / Send / Receive links
- [ ] `/`, `/send`, `/receive`, `/r/CODE`, `/how`, `/brand`, `/terms`, `/privacy` unchanged
- [ ] No horizontal overflow at 360–430px
- [ ] `pnpm --filter @warp/web build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated 404 page for unavailable routes.
  * Included navigation links to return home or access file transfer options.
  * Added SEO metadata for page-not-found routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->