### PR TITLE
fix(receive): auto-connect on a full pasted room code

### DIFF
--- a/web/src/receive/ReceiveEntry.tsx
+++ b/web/src/receive/ReceiveEntry.tsx
@@ -171,6 +171,13 @@ export default function ReceiveEntry() {
             className="rcv-input"
             value={code}
             onChange={(e) => setCode(sanitize(e.target.value))}
+            onPaste={(e) => {
+              e.preventDefault();
+              const next = sanitize(e.clipboardData.getData("text"));
+              setCode(next);
+              // Full valid paste → connect immediately (typing the 6th char does not).
+              if (VALID_RE.test(next)) navigate("/r/" + next);
+            }}
             onKeyDown={(e) => {
               if (e.key === "Enter") connect();
             }}


### PR DESCRIPTION
## Summary
- `/receive` input `onPaste` sanitizes clipboard text and, when the result is a valid 6-char code, navigates to `/r/<CODE>` immediately.
- Partial/invalid pastes only fill the field; typing the sixth character by hand does not auto-navigate.
- Fixes #68

## Test plan
- [ ] Paste `abc-def` / `ABC DEF` / `abcdef` (valid alphabet) → connects without another tap
- [ ] Paste partial or invalid code → field fills, no navigate
- [ ] Typing six chars still needs Enter or Connect
- [ ] Mobile long-press paste at 360–430px
- [ ] `pnpm --filter @warp/web build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved room code pasting by automatically sanitizing pasted text.
  * Automatically joins the room when a pasted code is complete and valid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->