### PR TITLE
fix(web): shared room-code module + pre-check /r deep links

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8,6 +8,7 @@ import BrandKit from "./brand/BrandKit";
 import Legal from "./legal/Legal";
 import { useRoute } from "./router";
 import { useDocumentSeo } from "./lib/useDocumentSeo";
+import { VALID_RE, sanitize } from "./lib/warp/roomCode";
 
 const CHANNEL_DESC =
   "Open a secure peer-to-peer channel and send files straight to another device.";
@@ -67,7 +68,14 @@ export default function App() {
 
   if (path === "/send") return <TransferFlow />;
   if (path === "/receive") return <ReceiveEntry />;
-  if (path.startsWith("/r/") && code) return <TransferFlow joinCode={code} />;
+  if (path.startsWith("/r/") && code) {
+    const cleaned = sanitize(code);
+    if (VALID_RE.test(cleaned)) {
+      return <TransferFlow joinCode={cleaned} />;
+    }
+    // Malformed deep link — show the receive form with a hint, no WebSocket yet.
+    return <ReceiveEntry initialCode={cleaned} />;
+  }
   if (path === "/how") return <Theory />;
   if (path === "/brand") return <BrandKit />;
   if (path === "/terms") return <Legal kind="terms" />;

--- a/web/src/lib/warp/roomCode.ts
+++ b/web/src/lib/warp/roomCode.ts
@@ -1,0 +1,19 @@
+/**
+ * Shared room-code alphabet helpers — matches the signaling server's
+ * `CODE_ALPHABET` / `ROOM_RE` in `server/src/index.js`. Client-side only for
+ * fast format checks; the server remains the authority.
+ */
+
+export const CODE_LEN = 6;
+
+/** Server alphabet: A–Z minus I, L, O + digits 2–9. */
+export const VALID_RE = /^[A-HJ-KM-NP-Z2-9]{6}$/;
+
+const ALLOWED_CHARS = /[A-HJ-KM-NP-Z2-9]/g;
+
+/** Strip whitespace/dashes, uppercase, drop disallowed chars, cap at CODE_LEN. */
+export function sanitize(raw: string): string {
+  const upper = raw.toUpperCase();
+  const kept = upper.match(ALLOWED_CHARS)?.join("") ?? "";
+  return kept.slice(0, CODE_LEN);
+}

--- a/web/src/receive/ReceiveEntry.tsx
+++ b/web/src/receive/ReceiveEntry.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from "react";
 import { navigate } from "../router";
 import WarpLogo from "../WarpLogo";
 import { useIsMobile } from "../lib/useIsMobile";
+import { CODE_LEN, VALID_RE, sanitize } from "../lib/warp/roomCode";
 
 /**
  * ReceiveEntry — the "/receive" page. The second device needs a way to *enter*
@@ -17,21 +18,14 @@ const MONO = "'JetBrains Mono',monospace";
 const DISPLAY = "'Bricolage Grotesque',sans-serif";
 const HAIR = "rgba(239,233,218,.14)";
 
-const CODE_LEN = 6;
-// Server alphabet: A-Z minus I,L,O + digits 2-9.
-const VALID_RE = /^[A-HJ-KM-NP-Z2-9]{6}$/;
-const ALLOWED_CHARS = /[A-HJ-KM-NP-Z2-9]/g;
-
-/** Strip whitespace/dashes, uppercase, drop disallowed chars, cap at 6. */
-function sanitize(raw: string): string {
-  const upper = raw.toUpperCase();
-  const kept = upper.match(ALLOWED_CHARS)?.join("") ?? "";
-  return kept.slice(0, CODE_LEN);
-}
-
-export default function ReceiveEntry() {
+export default function ReceiveEntry({
+  initialCode = "",
+}: {
+  /** Prefill from a malformed `/r/:code` deep link (already sanitized). */
+  initialCode?: string;
+}) {
   const isMobile = useIsMobile();
-  const [code, setCode] = useState("");
+  const [code, setCode] = useState(() => sanitize(initialCode));
 
   const valid = useMemo(() => VALID_RE.test(code), [code]);
   // Only nag once they've typed a full-length code that still doesn't match.


### PR DESCRIPTION
## Summary
- Extract `CODE_LEN`, `VALID_RE`, and `sanitize()` into `web/src/lib/warp/roomCode.ts`.
- `/r/:code` is sanitized first; valid codes (including lowercase) open `TransferFlow`, invalid ones open `ReceiveEntry` with `initialCode` and no signaling dial.
- Fixes #69

## Test plan
- [ ] `/r/ABC234` connects as before; `/r/abc234` also connects
- [ ] `/r/hello!!` shows receive page with sanitized attempt, no WebSocket
- [ ] `git grep -n VALID_RE -- web/src` → only `roomCode.ts`
- [ ] `pnpm --filter @warp/web build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for opening receive pages with prefilled room codes from shared links.
  * Automatically cleans up room codes by removing spaces, dashes, and invalid characters.
  * Valid room codes now proceed directly to the transfer flow.

* **Bug Fixes**
  * Invalid or malformed shared-link codes now remain in the receive form for correction instead of starting an invalid transfer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->