### PR TITLE
feat(pair): add Copy code next to Copy link

### DIFF
--- a/web/src/transfer/TransferFlow.tsx
+++ b/web/src/transfer/TransferFlow.tsx
@@ -650,8 +650,8 @@ function PairStep({
   onRemove: (id: string) => void;
   isMobile: boolean;
 }) {
-  const [copied, setCopied] = useState(false);
-  const [copyFailed, setCopyFailed] = useState(false);
+  const [copied, setCopied] = useState<"link" | "code" | null>(null);
+  const [copyFailed, setCopyFailed] = useState<"link" | "code" | null>(null);
   const [qrSvg, setQrSvg] = useState<string>("");
   const canShare = typeof navigator !== "undefined" && typeof navigator.share === "function";
 
@@ -670,17 +670,32 @@ function PairStep({
     };
   }, [shareUrl]);
 
+
   const copy = async () => {
     if (!shareUrl) return;
     const ok = await copyToClipboard(shareUrl);
     if (ok) {
-      setCopied(true);
-      setCopyFailed(false);
-      setTimeout(() => setCopied(false), 1800);
+      setCopied("link");
+      setCopyFailed(null);
+      setTimeout(() => setCopied((cur) => (cur === "link" ? null : cur)), 1500);
     } else {
-      setCopyFailed(true);
-      setCopied(false);
-      setTimeout(() => setCopyFailed(false), 2400);
+      setCopyFailed("link");
+      setCopied(null);
+      setTimeout(() => setCopyFailed((cur) => (cur === "link" ? null : cur)), 2400);
+    }
+  };
+
+  const copyCode = async () => {
+    if (!code) return;
+    const ok = await copyToClipboard(code);
+    if (ok) {
+      setCopied("code");
+      setCopyFailed(null);
+      setTimeout(() => setCopied((cur) => (cur === "code" ? null : cur)), 1500);
+    } else {
+      setCopyFailed("code");
+      setCopied(null);
+      setTimeout(() => setCopyFailed((cur) => (cur === "code" ? null : cur)), 2400);
     }
   };
 
@@ -872,27 +887,50 @@ function PairStep({
               type="button"
               className="warp-share"
               onClick={copy}
+              disabled={!shareUrl}
               style={
                 isMobile
                   ? {
                       ...shareBtn,
                       display: "block",
                       textAlign: "center",
-                      color: copyFailed ? "var(--amb)" : copied ? "var(--acc)" : shareBtn.color,
+                      color: copyFailed === "link" ? "var(--amb)" : copied === "link" ? "var(--acc)" : shareBtn.color,
                     }
                   : {
                       ...shareBtn,
-                      color: copyFailed ? "var(--amb)" : copied ? "var(--acc)" : shareBtn.color,
+                      color: copyFailed === "link" ? "var(--amb)" : copied === "link" ? "var(--acc)" : shareBtn.color,
                     }
               }
             >
-              {copyFailed ? "✕ copy failed" : copied ? "✓ copied!" : "⧉ Copy link"}
+              {copyFailed === "link" ? "✕ copy failed" : copied === "link" ? "✓ copied!" : "⧉ Copy link"}
+            </button>
+            <button
+              type="button"
+              className="warp-share"
+              onClick={copyCode}
+              disabled={!code}
+              style={
+                isMobile
+                  ? {
+                      ...shareBtn,
+                      display: "block",
+                      textAlign: "center",
+                      color: copyFailed === "code" ? "var(--amb)" : copied === "code" ? "var(--acc)" : shareBtn.color,
+                    }
+                  : {
+                      ...shareBtn,
+                      color: copyFailed === "code" ? "var(--amb)" : copied === "code" ? "var(--acc)" : shareBtn.color,
+                    }
+              }
+            >
+              {copyFailed === "code" ? "✕ copy failed" : copied === "code" ? "✓ copied!" : "⬚ Copy code"}
             </button>
             {canShare && (
               <button
                 type="button"
                 className="warp-share"
                 onClick={share}
+                disabled={!shareUrl}
                 style={isMobile ? { ...shareBtn, display: "block", textAlign: "center" } : shareBtn}
               >
                 ↗ Share


### PR DESCRIPTION
## Summary
- Pair screen share row gains a **Copy code** button that writes the 6-char `joined.room` code (no URL) to the clipboard.
- Per-button `✓ copied!` feedback via `useState<"link" | "code" | null>`.
- Share-row actions are real `<button type="button">` elements for keyboard access.
- Fixes #22

## Test plan
- [ ] Copy code puts exactly the 6-char code on the clipboard
- [ ] Copy link then Copy code shows feedback on the right control
- [ ] Row wraps cleanly at ~360px with three items
- [ ] Tab + Enter/Space activate the buttons
- [ ] `pnpm --filter @warp/web build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated **“Copy code”** action during the pairing step.
  * Added separate clipboard feedback for **copying the share link vs. copying the pairing code**.

* **Bug Fixes**
  * “Copy link” and “Copy code” actions are now **disabled when their respective value is unavailable**.
  * Improved clipboard feedback behavior to more clearly reflect **successful copy vs. copy failure**.

* **UI/UX**
  * Share row updated to show distinct actions with labels and colors reflecting the latest copy status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds a \"Copy code\" button to the `PairStep` share row that writes the server-minted 6-char room code to the clipboard, independent of the full share URL. The `copied` / `copyFailed` booleans are promoted to `\"link\" | \"code\" | null` discriminants, giving each button its own isolated feedback, and `disabled` props are wired to guard all three actions.

- **State modelling**: The string-discriminated state and functional `setTimeout` updaters (`cur === \"link\" ? null : cur`) cleanly avoid stale-closure races between rapid button presses.
- **Failure path cross-clearing**: Both `copy` and `copyCode` call `setCopied(null)` unconditionally in their error branches, so a failure on one button immediately erases the \"✓ copied!\" feedback that is actively showing on the other button rather than waiting for its scheduled timeout.
- **Mobile layout**: The share row uses `flexDirection: column` on mobile, so the third button stacks correctly; the CLAUDE.md requirement for zero horizontal overflow at ~360 px appears satisfied.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge; the change is self-contained and the core copy logic is correct.

The new Copy code path correctly guards against a null code prop, uses server-minted codes only, and the functional setTimeout updaters prevent stale-closure races. The one rough edge is that a failure on either button unconditionally resets the sibling button's "✓ copied!" display early — a minor feedback inconsistency visible to users that does not affect clipboard correctness or any data path.

web/src/transfer/TransferFlow.tsx — the failure-branch state resets in copy and copyCode.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/src/transfer/TransferFlow.tsx | Adds "Copy code" button alongside "Copy link" with per-button string-discriminated feedback state; functional setTimeout updaters are correct, but the failure path eagerly clears the sibling button's success state via unconditional setCopied(null). |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant CopyLink as Copy link button
    participant CopyCode as Copy code button
    participant State as React state(copied / copyFailed)
    participant Clipboard

    User->>CopyLink: click
    CopyLink->>Clipboard: copyToClipboard(shareUrl)
    Clipboard-->>CopyLink: "ok=true"
    CopyLink->>State: setCopied(link), setCopyFailed(null)
    Note over State: copied=link
    CopyLink->>State: setTimeout 1500ms clear link

    User->>CopyCode: click within 1500ms
    CopyCode->>Clipboard: copyToClipboard(code)
    Clipboard-->>CopyCode: "ok=false"
    CopyCode->>State: setCopyFailed(code), setCopied(null)
    Note over State: copied=null, link success cleared early
    CopyCode->>State: setTimeout 2400ms clear code
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aweb%2Fsrc%2Ftransfer%2FTransferFlow.tsx%3A681-684%0A**Failure%20path%20eagerly%20clears%20the%20other%20button's%20success%20feedback**%0A%0ABoth%20%60copy%60%20and%20%60copyCode%60%20call%20%60setCopied%28null%29%60%20in%20their%20failure%20branches.%20If%20the%20user%20clicks%20%22Copy%20code%22%20%28succeeds%2C%20button%20shows%20%22%E2%9C%93%20copied!%22%29%20and%20then%20quickly%20clicks%20%22Copy%20link%22%20which%20fails%2C%20%60setCopied%28null%29%60%20instantly%20wipes%20the%20%22%E2%9C%93%20copied!%22%20state%20on%20the%20Copy%20code%20button%20%E2%80%94%201400ms%20earlier%20than%20the%20scheduled%20timeout.%20The%20functional%20updaters%20in%20the%20%60setTimeout%60%20callbacks%20correctly%20guard%20against%20stale-closure%20issues%2C%20but%20the%20immediate%20%60setCopied%28null%29%60%20on%20failure%20is%20the%20real%20problem.%0A%0A&repo=ishannaik%2Fwarp&pr=80&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ishannaik%2Fwarp%22%20on%20the%20existing%20branch%20%22fix%2F22-copy-code-button%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F22-copy-code-button%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aweb%2Fsrc%2Ftransfer%2FTransferFlow.tsx%3A681-684%0A**Failure%20path%20eagerly%20clears%20the%20other%20button's%20success%20feedback**%0A%0ABoth%20%60copy%60%20and%20%60copyCode%60%20call%20%60setCopied%28null%29%60%20in%20their%20failure%20branches.%20If%20the%20user%20clicks%20%22Copy%20code%22%20%28succeeds%2C%20button%20shows%20%22%E2%9C%93%20copied!%22%29%20and%20then%20quickly%20clicks%20%22Copy%20link%22%20which%20fails%2C%20%60setCopied%28null%29%60%20instantly%20wipes%20the%20%22%E2%9C%93%20copied!%22%20state%20on%20the%20Copy%20code%20button%20%E2%80%94%201400ms%20earlier%20than%20the%20scheduled%20timeout.%20The%20functional%20updaters%20in%20the%20%60setTimeout%60%20callbacks%20correctly%20guard%20against%20stale-closure%20issues%2C%20but%20the%20immediate%20%60setCopied%28null%29%60%20on%20failure%20is%20the%20real%20problem.%0A%0A&repo=ishannaik%2Fwarp&pr=80&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aweb%2Fsrc%2Ftransfer%2FTransferFlow.tsx%3A681-684%0A**Failure%20path%20eagerly%20clears%20the%20other%20button's%20success%20feedback**%0A%0ABoth%20%60copy%60%20and%20%60copyCode%60%20call%20%60setCopied%28null%29%60%20in%20their%20failure%20branches.%20If%20the%20user%20clicks%20%22Copy%20code%22%20%28succeeds%2C%20button%20shows%20%22%E2%9C%93%20copied!%22%29%20and%20then%20quickly%20clicks%20%22Copy%20link%22%20which%20fails%2C%20%60setCopied%28null%29%60%20instantly%20wipes%20the%20%22%E2%9C%93%20copied!%22%20state%20on%20the%20Copy%20code%20button%20%E2%80%94%201400ms%20earlier%20than%20the%20scheduled%20timeout.%20The%20functional%20updaters%20in%20the%20%60setTimeout%60%20callbacks%20correctly%20guard%20against%20stale-closure%20issues%2C%20but%20the%20immediate%20%60setCopied%28null%29%60%20on%20failure%20is%20the%20real%20problem.%0A%0A&pr=80&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/transfer/TransferFlow.tsx:681-684
**Failure path eagerly clears the other button's success feedback**

Both `copy` and `copyCode` call `setCopied(null)` in their failure branches. If the user clicks "Copy code" (succeeds, button shows "✓ copied!") and then quickly clicks "Copy link" which fails, `setCopied(null)` instantly wipes the "✓ copied!" state on the Copy code button — 1400ms earlier than the scheduled timeout. The functional updaters in the `setTimeout` callbacks correctly guard against stale-closure issues, but the immediate `setCopied(null)` on failure is the real problem.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(pair): add Copy code next to Copy l..."](https://github.com/ishannaik/warp/commit/21d3a0c0055b95d90c835a6cbf27669500cd9869) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45974016)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/ishannaik/github/Ishannaik/warp/-/custom-context?memory=575c40ec-32b8-4814-a2b7-1ced5808ec85))

<!-- /greptile_comment -->