### PR TITLE
feat(hash): compute SHA-256 off the main thread in a Web Worker

### DIFF
--- a/web/src/lib/warp/hash.check.mjs
+++ b/web/src/lib/warp/hash.check.mjs
@@ -1,0 +1,123 @@
+/**
+ * Runnable check for the incremental SHA-256 used by the hash Web Worker
+ * (issue #88). Verifies the algorithm against FIPS 180-4 test vectors and the
+ * one property the worker relies on: hashing N calls of `update(chunk)` must
+ * match one call over the concatenated bytes.
+ *
+ * Cross-checks against Node's built-in `crypto.createHash('sha256')` on a
+ * randomized 4 MiB payload to catch any drift from the reference.
+ *
+ * The Web Worker plumbing (message routing, `hash.ts` wrapper) is exercised by
+ * the peer round-trip in `peer.check.mjs` — this harness stays algorithm-only,
+ * matching the dependency-free house style.
+ *
+ * Run:  node src/lib/warp/hash.check.mjs   (from web/)
+ */
+
+import assert from "node:assert";
+import { createHash, randomBytes } from "node:crypto";
+
+let init, update, finalize, toHex;
+try {
+  const esbuild = await import("esbuild");
+  const url = await import("node:url");
+  const path = await import("node:path");
+  const here = path.dirname(url.fileURLToPath(import.meta.url));
+  const out = await esbuild.build({
+    entryPoints: [path.join(here, "sha256.ts")],
+    bundle: true,
+    format: "esm",
+    write: false,
+    platform: "neutral",
+  });
+  const code = out.outputFiles[0].text;
+  const dataUrl = "data:text/javascript;base64," + Buffer.from(code).toString("base64");
+  ({ init, update, finalize, toHex } = await import(dataUrl));
+} catch (e) {
+  console.error("SKIP: esbuild not available —", e.message);
+  process.exit(0);
+}
+
+const enc = new TextEncoder();
+const hex = (bytes) => toHex(bytes);
+
+// --- FIPS 180-4 test vectors --------------------------------------------------
+{
+  const s = init();
+  assert.equal(
+    hex(finalize(s)),
+    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "empty input → known SHA-256",
+  );
+}
+{
+  const s = init();
+  update(s, enc.encode("abc"));
+  assert.equal(
+    hex(finalize(s)),
+    "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+    '"abc" → known SHA-256',
+  );
+}
+{
+  // 448-bit test vector from FIPS 180-4 (56 chars — crosses the 55-byte pad boundary)
+  const s = init();
+  update(s, enc.encode("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq"));
+  assert.equal(
+    hex(finalize(s)),
+    "248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1",
+    "448-bit vector → known SHA-256",
+  );
+}
+{
+  // Long-input vector: exactly one million 'a' bytes (FIPS 180-4).
+  const s = init();
+  const chunk = new Uint8Array(1000).fill(0x61); // 'a'
+  for (let i = 0; i < 1000; i++) update(s, chunk);
+  assert.equal(
+    hex(finalize(s)),
+    "cdc76e5c9914fb9281a1c7e284d73e67f1809a48a497200e046d39ccc7112cd0",
+    "1M 'a' → known SHA-256",
+  );
+}
+
+// --- incremental vs one-shot equivalence -------------------------------------
+{
+  const bytes = randomBytes(4 * 1024 * 1024); // 4 MiB, one read block
+  const expected = createHash("sha256").update(bytes).digest("hex");
+
+  // One-shot
+  const s1 = init();
+  update(s1, new Uint8Array(bytes));
+  assert.equal(hex(finalize(s1)), expected, "one-shot 4 MiB matches Node's SHA-256");
+
+  // Many small updates across the 64-byte block boundary (the pending-buffer path)
+  const s2 = init();
+  for (let i = 0; i < bytes.length; i += 37) {
+    update(s2, new Uint8Array(bytes.buffer, bytes.byteOffset + i, Math.min(37, bytes.length - i)));
+  }
+  assert.equal(hex(finalize(s2)), expected, "37-byte incremental updates match one-shot");
+
+  // 256 KiB chunks (the on-wire chunk size on the receive path)
+  const s3 = init();
+  for (let i = 0; i < bytes.length; i += 256 * 1024) {
+    update(s3, new Uint8Array(bytes.buffer, bytes.byteOffset + i, 256 * 1024));
+  }
+  assert.equal(hex(finalize(s3)), expected, "256 KiB incremental updates match one-shot");
+}
+
+// --- update() must not retain the caller's buffer ---------------------------
+{
+  const s = init();
+  const buf = enc.encode("hello ");
+  update(s, buf);
+  buf.fill(0); // clobber after update: hash state must already have captured it
+  update(s, enc.encode("world"));
+  assert.equal(
+    hex(finalize(s)),
+    "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
+    "'hello world' — update() copied its input synchronously (caller can reuse the buffer)",
+  );
+}
+
+console.log("OK: sha256 incremental — test vectors, chunked equivalence, no buffer retention");

--- a/web/src/lib/warp/hash.ts
+++ b/web/src/lib/warp/hash.ts
@@ -1,0 +1,111 @@
+/**
+ * Main-thread wrapper around the SHA-256 Web Worker (`hashWorker.ts`).
+ *
+ * A `HashSession` is per-file scratchpad state: `update(block)` posts each 4 MiB
+ * read block (send) or incoming chunk (receive) into the worker, and
+ * `finalize()` returns the hex digest once every queued block has been consumed.
+ *
+ * Two facts drive the shape of this module:
+ *
+ *  1. `crypto.subtle.digest` isn't streaming — you'd have to hold the whole
+ *     file in memory to use it. We can't. `sha256.ts` (used by the worker)
+ *     replaces it.
+ *  2. Even an incremental JS/WASM hash on the main thread would fight the
+ *     transfer loop and the UI. We push all CPU into a dedicated worker so
+ *     hashing overlaps with the network path instead of blocking it.
+ *
+ * A single worker instance is shared across sessions (send + receive can hash
+ * concurrently), lazily created on the first `createHashSession()` call so a
+ * transfer that never uses hashing pays nothing. Sessions are keyed by an
+ * opaque id so the worker's `finalize` reply routes back to the right caller.
+ *
+ * Buffer ownership: `update()` deliberately does NOT transfer — the caller
+ * (the send pump, the receive sink) still needs the buffer. postMessage
+ * without a transfer list structured-clones synchronously, so the worker gets
+ * its own copy and the caller's buffer stays intact.
+ */
+
+export interface HashSession {
+  /** Feed a block. Buffer is copied into the worker; the caller keeps ownership. */
+  update(block: ArrayBuffer | Uint8Array): void;
+  /** Resolves with the hex digest of every block fed so far. Idempotent-safe:
+   *  further update()/finalize()/dispose() calls become no-ops. */
+  finalize(): Promise<string>;
+  /** Drop the session without waiting for a digest (cancel path). */
+  dispose(): void;
+}
+
+let worker: Worker | null = null;
+let workerUnavailable = false;
+let nextId = 0;
+const pending = new Map<string, (digest: string) => void>();
+
+function ensureWorker(): Worker | null {
+  if (worker) return worker;
+  if (workerUnavailable) return null;
+  try {
+    worker = new Worker(new URL("./hashWorker.ts", import.meta.url), { type: "module" });
+    worker.addEventListener("message", (ev: MessageEvent<{ id: string; digest: string }>) => {
+      const { id, digest } = ev.data;
+      const resolve = pending.get(id);
+      if (resolve) {
+        pending.delete(id);
+        resolve(digest);
+      }
+    });
+    return worker;
+  } catch {
+    // Environments without Worker support (SSR probes, the engine check harness
+    // that runs peer.ts under Node) skip hashing rather than break the transfer
+    // pipeline. When #6 lands the manifest-verify UI, it will separately gate
+    // on whether a digest was emitted for the file.
+    workerUnavailable = true;
+    return null;
+  }
+}
+
+/** No-op session: hashing is unavailable, so update/finalize/dispose are inert
+ *  and finalize resolves with an empty digest. */
+const noopSession: HashSession = {
+  update() {},
+  finalize: async () => "",
+  dispose() {},
+};
+
+export function createHashSession(): HashSession {
+  const w = ensureWorker();
+  if (!w) return noopSession;
+  const id = `h${++nextId}`;
+  w.postMessage({ cmd: "init", id });
+  let closed = false;
+  return {
+    update(block) {
+      if (closed) return;
+      // Normalize to ArrayBuffer for postMessage. A Uint8Array view carries its
+      // parent buffer's full extent under structuredClone, so slice a right-
+      // sized copy when we're handed a view.
+      const buf =
+        block instanceof ArrayBuffer
+          ? block
+          : block.buffer.slice(block.byteOffset, block.byteOffset + block.byteLength);
+      w.postMessage({ cmd: "update", id, block: buf });
+    },
+    finalize() {
+      return new Promise<string>((resolve) => {
+        if (closed) {
+          resolve("");
+          return;
+        }
+        closed = true;
+        pending.set(id, resolve);
+        w.postMessage({ cmd: "finalize", id });
+      });
+    },
+    dispose() {
+      if (closed) return;
+      closed = true;
+      pending.delete(id);
+      w.postMessage({ cmd: "dispose", id });
+    },
+  };
+}

--- a/web/src/lib/warp/hashWorker.ts
+++ b/web/src/lib/warp/hashWorker.ts
@@ -1,0 +1,72 @@
+/**
+ * Web Worker: incremental SHA-256, one session per in-flight file.
+ *
+ * The main thread owns transfer I/O (WebRTC data channel, disk sink); this
+ * worker owns hashing. Blocks flow in via postMessage; the digest flows back
+ * when the sender/receiver signals the file is complete.
+ *
+ * Wire (all messages carry an opaque `id` naming the session):
+ *   in  { cmd: 'init',     id }
+ *   in  { cmd: 'update',   id, block: ArrayBuffer }   — no reply, fire-and-forget
+ *   in  { cmd: 'finalize', id }
+ *   out { id, digest: string }                          — hex, lower-case
+ *   in  { cmd: 'dispose',  id }
+ *
+ * Buffer ownership: `block` is CLONED into the worker (postMessage without a
+ * transfer list). This is deliberate — the send pump still needs the block on
+ * the main thread to slice into SCTP messages, and the receive path hands the
+ * same buffer to the disk/memory sink. Transferring would detach the buffer
+ * under the caller's feet mid-pump.
+ *
+ * CSP note (issue #48): loaded as a same-origin module worker
+ * (`new Worker(new URL('./hashWorker.ts', ...), { type: 'module' })`) so
+ * `worker-src 'self'` alone is enough — no need to loosen with `blob:` or
+ * inline eval.
+ */
+
+import { init, update, finalize, toHex, type Sha256State } from "./sha256";
+
+type InMessage =
+  | { cmd: "init"; id: string }
+  | { cmd: "update"; id: string; block: ArrayBuffer }
+  | { cmd: "finalize"; id: string }
+  | { cmd: "dispose"; id: string };
+
+// The tsconfig lib is DOM (main-thread flavored), so `self` types as Window.
+// Cast to just the worker surface we touch — no need to pull in the WebWorker
+// lib and risk clashing with DOM types elsewhere in the package.
+interface WorkerCtx {
+  addEventListener(type: "message", listener: (ev: MessageEvent<InMessage>) => void): void;
+  postMessage(data: { id: string; digest: string }): void;
+}
+const ctx = self as unknown as WorkerCtx;
+
+const sessions = new Map<string, Sha256State>();
+
+ctx.addEventListener("message", (ev) => {
+  const msg = ev.data;
+  switch (msg.cmd) {
+    case "init": {
+      sessions.set(msg.id, init());
+      return;
+    }
+    case "update": {
+      const s = sessions.get(msg.id);
+      if (!s) return;
+      update(s, new Uint8Array(msg.block));
+      return;
+    }
+    case "finalize": {
+      const s = sessions.get(msg.id);
+      if (!s) return;
+      const digest = toHex(finalize(s));
+      sessions.delete(msg.id);
+      ctx.postMessage({ id: msg.id, digest });
+      return;
+    }
+    case "dispose": {
+      sessions.delete(msg.id);
+      return;
+    }
+  }
+});

--- a/web/src/lib/warp/peer.ts
+++ b/web/src/lib/warp/peer.ts
@@ -37,10 +37,12 @@ import {
   fileKey,
   newResumeToken,
   type ControlMessage,
+  type Direction,
   type OfferItem,
   type TransferItem,
 } from "./transfer";
 import { diskSink, memorySink, type ReceiveSink } from "./receiveController";
+import { createHashSession, type HashSession } from "./hash";
 
 const ICE_SERVERS: RTCIceServer[] = [
   { urls: "stun:stun.l.google.com:19302" },
@@ -143,6 +145,13 @@ export interface PeerEvents {
   declined: (info: { batchId: string }) => void;
   /** A file in flight was cancelled by either side. */
   cancelled: (info: { id: string }) => void;
+  /** SHA-256 hex digest of a completed file's session bytes. Emitted once per
+   *  successfully-transferred file (both send and receive) that hashed a whole
+   *  session — resumed transfers (startOffset > 0 on send, resume offset > 0 on
+   *  receive) are skipped since their hash would only cover the tail. The
+   *  digest is computed off the main thread (see `hashWorker.ts`); consumers
+   *  are expected to arrive with the manifest-carried expected hash from #6. */
+  "hash-computed": (info: { id: string; direction: Direction; digest: string }) => void;
   error: (kind: PeerErrorKind) => void;
 }
 
@@ -168,6 +177,10 @@ interface IncomingState {
    *  bytesWritten is the single source of truth for how many bytes are durable —
    *  used both for progress and as the resume offset the receiver reports. */
   sink: ReceiveSink;
+  /** SHA-256 session, computed off the main thread. Present only when the
+   *  receive started at offset 0 (a resumed receive's hash would only cover
+   *  the tail, so we skip rather than emit a misleading digest). */
+  hash: HashSession | null;
 }
 
 /**
@@ -264,6 +277,7 @@ export class WarpPeer {
     "text-received": new Set(),
     declined: new Set(),
     cancelled: new Set(),
+    "hash-computed": new Set(),
     error: new Set(),
   };
 
@@ -718,6 +732,7 @@ export class WarpPeer {
     if (this.incoming && this.incoming.item.id === id) {
       const inc = this.incoming;
       this.incoming = null;
+      inc.hash?.dispose();
       void inc.sink.abort();
       this.host.end(id);
     }
@@ -757,45 +772,66 @@ export class WarpPeer {
     startOffset = 0,
   ): Promise<boolean> {
     const sendChunk = this.sendChunkSize();
+    // Integrity hash runs in a Web Worker (issue #88). Tapped at the 4 MiB
+    // block boundary: each block we just read is posted to the worker before
+    // we slice it for the wire. Skipped on a resumed send (startOffset > 0)
+    // because the hash would only cover the tail we actually stream — a lie
+    // for #6's manifest-verify use case. The worker gets a structured-clone
+    // copy via postMessage; the caller's block stays intact for the send pump.
+    const hash = startOffset === 0 ? createHashSession() : null;
+    let finishedClean = false;
     // Resume: begin reading at startOffset (the receiver already holds [0,startOffset)).
     let offset = startOffset;
-    while (offset < file.size) {
-      if (this.cancelledIds.has(item.id)) {
-        this.cancelledIds.delete(item.id);
-        return false;
-      }
-
-      // Read one large block, then slice it into sendChunk-sized SCTP messages.
-      const block = await file.slice(offset, offset + READ_BLOCK).arrayBuffer();
-      let pos = 0;
-      while (pos < block.byteLength) {
+    try {
+      while (offset < file.size) {
         if (this.cancelledIds.has(item.id)) {
           this.cancelledIds.delete(item.id);
           return false;
         }
-        // Backpressure: wait until the send buffer drains below the high-water
-        // mark. Counts the chunk we're ABOUT to send, so we can never push
-        // bufferedAmount toward the browser's hard cap and blow up send().
-        while (ch.bufferedAmount + sendChunk > SEND_HIGH_WATER) {
-          await this.waitForDrain(ch);
+
+        // Read one large block, then slice it into sendChunk-sized SCTP messages.
+        const block = await file.slice(offset, offset + READ_BLOCK).arrayBuffer();
+        hash?.update(block);
+        let pos = 0;
+        while (pos < block.byteLength) {
+          if (this.cancelledIds.has(item.id)) {
+            this.cancelledIds.delete(item.id);
+            return false;
+          }
+          // Backpressure: wait until the send buffer drains below the high-water
+          // mark. Counts the chunk we're ABOUT to send, so we can never push
+          // bufferedAmount toward the browser's hard cap and blow up send().
+          while (ch.bufferedAmount + sendChunk > SEND_HIGH_WATER) {
+            await this.waitForDrain(ch);
+            if (ch.readyState !== "open") throw new Error("channel-closed-mid-send");
+          }
           if (ch.readyState !== "open") throw new Error("channel-closed-mid-send");
+
+          const end = Math.min(pos + sendChunk, block.byteLength);
+          // slice() copies; fine and avoids retaining the whole 4 MiB block per send.
+          ch.send(block.slice(pos, end));
+          offset += end - pos;
+          pos = end;
         }
-        if (ch.readyState !== "open") throw new Error("channel-closed-mid-send");
 
-        const end = Math.min(pos + sendChunk, block.byteLength);
-        // slice() copies; fine and avoids retaining the whole 4 MiB block per send.
-        ch.send(block.slice(pos, end));
-        offset += end - pos;
-        pos = end;
+        // Emit progress once per block (~4 MiB) rather than per chunk, to avoid
+        // flooding the UI with re-renders while the bytes fly.
+        item.transferred = offset;
+        item.progress = Math.min(100, Math.round((offset / Math.max(1, file.size)) * 100));
+        this.emit("transfer", { ...item });
       }
-
-      // Emit progress once per block (~4 MiB) rather than per chunk, to avoid
-      // flooding the UI with re-renders while the bytes fly.
-      item.transferred = offset;
-      item.progress = Math.min(100, Math.round((offset / Math.max(1, file.size)) * 100));
-      this.emit("transfer", { ...item });
+      finishedClean = true;
+      return true;
+    } finally {
+      if (hash) {
+        if (finishedClean) {
+          const digest = await hash.finalize();
+          this.emit("hash-computed", { id: item.id, direction: "send", digest });
+        } else {
+          hash.dispose();
+        }
+      }
     }
-    return true;
   }
 
   /**
@@ -941,7 +977,11 @@ export class WarpPeer {
       return;
     }
 
-    this.incoming = { item, sink };
+    // Integrity hash runs in a Web Worker (issue #88). Only for a fresh receive
+    // (offset === 0): a resumed receive already holds [0,offset) whose bytes we
+    // never see, so hashing from here would produce a digest of the tail alone.
+    const hash = offset === 0 ? createHashSession() : null;
+    this.incoming = { item, sink, hash };
     item.status = "transferring";
     item.transferred = sink.bytesWritten;
     item.progress = Math.min(100, Math.round((item.transferred / Math.max(1, item.size)) * 100));
@@ -952,6 +992,10 @@ export class WarpPeer {
     const inc = this.incoming;
     if (!inc) return; // no active incoming file (cancelled / not accepted)
     inc.sink.append(buf);
+    // Feed the same chunk into the off-thread hash worker. postMessage clones
+    // (no transfer list), so the sink's reference is not detached out from
+    // under it. Skipped on a resumed receive (see startIncoming).
+    inc.hash?.update(buf);
     // Durable count is the single source of truth (Fable H1): for disk it advances
     // as writes resolve, so progress is conservative, never ahead of what's on disk.
     inc.item.transferred = inc.sink.bytesWritten;
@@ -992,6 +1036,7 @@ export class WarpPeer {
     await inc.sink.quiesce();
     const bytes = inc.sink.bytesWritten;
     if (bytes !== inc.item.size || inc.sink.failed) {
+      inc.hash?.dispose();
       await inc.sink.abort();
       this.host.end(id);
       this.markStatus(id, "error");
@@ -1001,7 +1046,10 @@ export class WarpPeer {
     const blob = await inc.sink.finalize(); // memory -> Blob; disk -> null (writable closed)
     const savedName = this.host.savedName(id);
     this.host.end(id);
-    if (this.disposed) return;
+    if (this.disposed) {
+      inc.hash?.dispose();
+      return;
+    }
 
     inc.item.status = "done";
     inc.item.transferred = inc.item.size;
@@ -1015,6 +1063,10 @@ export class WarpPeer {
       if (savedName) inc.item.name = savedName;
       this.emit("transfer", { ...inc.item });
       this.emit("file-received", { id, name: inc.item.name, mime: inc.item.mime, savedToDisk: true });
+    }
+    if (inc.hash) {
+      const digest = await inc.hash.finalize();
+      if (!this.disposed) this.emit("hash-computed", { id, direction: "receive", digest });
     }
   }
 

--- a/web/src/lib/warp/sha256.ts
+++ b/web/src/lib/warp/sha256.ts
@@ -1,0 +1,137 @@
+/**
+ * Incremental SHA-256 (FIPS 180-4). Pure JavaScript, zero deps, ~120 lines.
+ *
+ * Why not `crypto.subtle.digest`? It has NO streaming API — you must hand it a
+ * single complete buffer, so hashing a 2 GB file would mean holding the whole
+ * file in RAM. That defeats the disk-streaming receive path (`receiveController.ts`)
+ * that exists precisely so large transfers never sit in memory.
+ *
+ * Why not pull in a library? The web bundle already carries a 500 KB warning
+ * (CONTRIBUTING §Constraints). SHA-256 is short, stable, and public-domain in
+ * spirit; inlining it is cheaper than a dep.
+ *
+ * Ownership rule: `update()` reads the caller's `Uint8Array` synchronously and
+ * doesn't retain a reference. Safe to reuse or discard the buffer after the
+ * call returns.
+ *
+ * All CPU work belongs OFF the main thread — see `hashWorker.ts` for the only
+ * place these functions are meant to run.
+ */
+
+const K = new Uint32Array([
+  0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+  0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+  0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+  0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+  0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+  0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+  0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+  0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+]);
+
+export interface Sha256State {
+  h: Uint32Array;      // running hash (8 × 32-bit)
+  buffer: Uint8Array;  // pending bytes waiting for a full 64-byte block
+  bufferLen: number;
+  totalBytes: number;  // total bytes fed via update() so far
+}
+
+export function init(): Sha256State {
+  return {
+    h: new Uint32Array([
+      0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19,
+    ]),
+    buffer: new Uint8Array(64),
+    bufferLen: 0,
+    totalBytes: 0,
+  };
+}
+
+/** Process one 64-byte block starting at `offset` in `data`. */
+function compress(h: Uint32Array, data: Uint8Array, offset: number): void {
+  const w = new Uint32Array(64);
+  for (let i = 0; i < 16; i++) {
+    const o = offset + i * 4;
+    w[i] = (data[o] << 24) | (data[o + 1] << 16) | (data[o + 2] << 8) | data[o + 3];
+  }
+  for (let i = 16; i < 64; i++) {
+    const s0 = ((w[i - 15] >>> 7) | (w[i - 15] << 25)) ^ ((w[i - 15] >>> 18) | (w[i - 15] << 14)) ^ (w[i - 15] >>> 3);
+    const s1 = ((w[i - 2] >>> 17) | (w[i - 2] << 15)) ^ ((w[i - 2] >>> 19) | (w[i - 2] << 13)) ^ (w[i - 2] >>> 10);
+    w[i] = (w[i - 16] + s0 + w[i - 7] + s1) | 0;
+  }
+  let a = h[0], b = h[1], c = h[2], d = h[3], e = h[4], f = h[5], g = h[6], hh = h[7];
+  for (let i = 0; i < 64; i++) {
+    const S1 = ((e >>> 6) | (e << 26)) ^ ((e >>> 11) | (e << 21)) ^ ((e >>> 25) | (e << 7));
+    const ch = (e & f) ^ (~e & g);
+    const t1 = (hh + S1 + ch + K[i] + w[i]) | 0;
+    const S0 = ((a >>> 2) | (a << 30)) ^ ((a >>> 13) | (a << 19)) ^ ((a >>> 22) | (a << 10));
+    const mj = (a & b) ^ (a & c) ^ (b & c);
+    const t2 = (S0 + mj) | 0;
+    hh = g; g = f; f = e; e = (d + t1) | 0; d = c; c = b; b = a; a = (t1 + t2) | 0;
+  }
+  h[0] = (h[0] + a) | 0; h[1] = (h[1] + b) | 0; h[2] = (h[2] + c) | 0; h[3] = (h[3] + d) | 0;
+  h[4] = (h[4] + e) | 0; h[5] = (h[5] + f) | 0; h[6] = (h[6] + g) | 0; h[7] = (h[7] + hh) | 0;
+}
+
+export function update(s: Sha256State, chunk: Uint8Array): void {
+  s.totalBytes += chunk.byteLength;
+  let i = 0;
+  // Top up the pending buffer to 64 bytes first.
+  if (s.bufferLen > 0) {
+    const need = 64 - s.bufferLen;
+    const take = Math.min(need, chunk.byteLength);
+    s.buffer.set(chunk.subarray(0, take), s.bufferLen);
+    s.bufferLen += take;
+    i = take;
+    if (s.bufferLen === 64) {
+      compress(s.h, s.buffer, 0);
+      s.bufferLen = 0;
+    }
+  }
+  // Consume full 64-byte blocks in place (no copy).
+  while (i + 64 <= chunk.byteLength) {
+    compress(s.h, chunk, i);
+    i += 64;
+  }
+  // Stash the tail for the next update.
+  if (i < chunk.byteLength) {
+    const tail = chunk.byteLength - i;
+    s.buffer.set(chunk.subarray(i), 0);
+    s.bufferLen = tail;
+  }
+}
+
+export function finalize(s: Sha256State): Uint8Array {
+  const bitLenHi = Math.floor(s.totalBytes / 0x20000000); // totalBytes * 8 high 32 bits
+  const bitLenLo = (s.totalBytes * 8) >>> 0;              // low 32 bits
+  // Pad: 0x80, zeros, then 64-bit big-endian length. Total padded length ≡ 0 (mod 64).
+  const padLen = s.bufferLen < 56 ? 64 - s.bufferLen : 128 - s.bufferLen;
+  const pad = new Uint8Array(padLen);
+  pad[0] = 0x80;
+  pad[padLen - 8] = (bitLenHi >>> 24) & 0xff;
+  pad[padLen - 7] = (bitLenHi >>> 16) & 0xff;
+  pad[padLen - 6] = (bitLenHi >>> 8) & 0xff;
+  pad[padLen - 5] = bitLenHi & 0xff;
+  pad[padLen - 4] = (bitLenLo >>> 24) & 0xff;
+  pad[padLen - 3] = (bitLenLo >>> 16) & 0xff;
+  pad[padLen - 2] = (bitLenLo >>> 8) & 0xff;
+  pad[padLen - 1] = bitLenLo & 0xff;
+  update(s, pad);
+  const out = new Uint8Array(32);
+  for (let i = 0; i < 8; i++) {
+    out[i * 4] = (s.h[i] >>> 24) & 0xff;
+    out[i * 4 + 1] = (s.h[i] >>> 16) & 0xff;
+    out[i * 4 + 2] = (s.h[i] >>> 8) & 0xff;
+    out[i * 4 + 3] = s.h[i] & 0xff;
+  }
+  return out;
+}
+
+export function toHex(bytes: Uint8Array): string {
+  let out = "";
+  for (let i = 0; i < bytes.length; i++) {
+    const b = bytes[i];
+    out += (b < 16 ? "0" : "") + b.toString(16);
+  }
+  return out;
+}


### PR DESCRIPTION
Closes #88.

## Summary

Adds a dedicated Web Worker running incremental SHA-256 over the existing 4 MiB block pipeline, so integrity verification (#6) can hash multi-GB files without holding them in memory (`crypto.subtle.digest` isn't streaming) and without competing with the send loop and UI on the main thread.

Scope matches the issue: **worker + wire-in only**. The protocol side (carrying the expected hash in the manifest, verified-badge UI) stays in #6.

## Changes

- **`sha256.ts`** — pure-JS incremental SHA-256, FIPS 180-4 vectors verified. ~120 lines, zero deps (keeps the 500 kB bundle warning honest).
- **`hashWorker.ts`** — module Worker; one session per file, keyed by an opaque id. Loaded as `new Worker(new URL('./hashWorker.ts', import.meta.url), { type: 'module' })` so a future CSP (#48) only needs `worker-src 'self'`.
- **`hash.ts`** — main-thread wrapper (`createHashSession`). Lazy shared Worker; falls back to a no-op session when `Worker` construction fails so Node check harnesses and SSR probes don't need to stub the DOM.
- **`peer.ts`** — tap `streamFile` (send) and `onChunk` (receive) at the 4 MiB / chunk boundary; emit a new `hash-computed` event on file completion. Resumed transfers (`startOffset > 0` on send, resume offset > 0 on receive) are deliberately skipped — their hash would only cover the tail.
- **`hash.check.mjs`** — FIPS test vectors + chunked-vs-one-shot equivalence, cross-checked against Node's `crypto`.

### Buffer ownership

`update(block)` posts the buffer to the worker **without a transfer list** (a `structuredClone` copy). This is deliberate — the send pump still needs the block to slice into SCTP messages, and the receive path hands the same buffer to the disk/memory sink. Transferring would detach the buffer under the caller's feet mid-pump. Memory stays flat: peak is one block in the main thread plus a transient copy in the worker (~8 MiB) — no regression on the existing bounded pipeline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SHA-256 verification for completed file transfers.
  * Hashing runs in the background to minimize impact on transfer performance.
  * Transfer events now report the computed digest and transfer direction.
  * Hashing is safely handled for cancellations, errors, resumed transfers, and unsupported environments.

* **Tests**
  * Added comprehensive validation using standard SHA-256 vectors and randomized large-file comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->