### PR TITLE
Memoize ItemRow and stabilize cancel/downloadOne to fix wasted re-renders

### DIFF
--- a/web/src/lib/warp/useWarpTransfer.ts
+++ b/web/src/lib/warp/useWarpTransfer.ts
@@ -801,7 +801,11 @@ export function useWarpTransfer(joinCode?: string): UseWarpTransfer {
       }
 
       // Route to the peer that owns the item; the item carries its peerId.
-      const item = items.find((t) => t.id === id);
+      // Reads itemsRef (kept in sync with `items`) instead of closing over
+      // `items` directly, so this callback's identity stays stable across
+      // progress ticks — otherwise every ItemRow using it as a prop would
+      // re-render on every tick regardless of React.memo.
+      const item = itemsRef.current.find((t) => t.id === id);
       const peer = item?.peerId ? peersRef.current.get(item.peerId) : undefined;
       if (peer) {
         peer.cancel(id);
@@ -811,17 +815,19 @@ export function useWarpTransfer(joinCode?: string): UseWarpTransfer {
       // no-op because they don't own the id.
       for (const p of peersRef.current.values()) p.cancel(id);
     },
-    [items],
+    [],
   );
 
   const downloadOne = useCallback(
     (id: string) => {
-      const item = items.find((t) => t.id === id);
+      // Same reasoning as cancel(): read itemsRef, not items, to keep this
+      // callback's reference stable across progress ticks.
+      const item = itemsRef.current.find((t) => t.id === id);
       // savedToDisk items are already on disk (no blob) -> nothing to download.
       if (!item || item.savedToDisk || !item.blob) return;
       saveBlob(item.blob, item.name);
     },
-    [items],
+    [],
   );
 
   const downloadAll = useCallback(() => {

--- a/web/src/transfer/SessionView.tsx
+++ b/web/src/transfer/SessionView.tsx
@@ -15,7 +15,7 @@
  * the global keyframes media query.
  */
 
-import { useRef, useState } from "react";
+import { memo, useRef, useState } from "react";
 import type { CSSProperties } from "react";
 import { formatBytes, type OfferItem, type TransferItem } from "../lib/warp/transfer";
 import type { Connection } from "../lib/warp/useWarpTransfer";
@@ -102,7 +102,11 @@ function statusColor(status: TransferItem["status"]): string {
   return "#908a7b";
 }
 
-function ItemRow({
+// Memoized: upsertItem preserves object identity for untouched items, so a
+// progress tick on one item re-renders only that item's row, not the whole
+// tray. onCancel/onDownload are useCallback-wrapped upstream, isMobile is a
+// primitive, and peerLabel is a primitive string — all memo-safe as-is.
+const ItemRow = memo(function ItemRow({
   item,
   onCancel,
   onDownload,
@@ -335,7 +339,7 @@ function ItemRow({
       )}
     </div>
   );
-}
+});
 
 const iconBtn: CSSProperties = {
   width: "30px",


### PR DESCRIPTION
Closes #89

**ItemRow** wrapped in React.memo, as the issue asked.

**Root cause found during testing:** wrapping ItemRow alone wasn't 
enough — Profiler showed every row still re-rendering on every 
progress tick. Traced it to useWarpTransfer.ts: `cancel` and 
`downloadOne` both had `[items]` in their useCallback dependency 
array. Since `items` gets a new array reference every tick (via 
upsertItem), both callbacks were recreated every tick too — and 
since they're passed straight down as onCancel/onDownload props to 
every ItemRow, React.memo's shallow comparison saw "changed props" 
on every row, every time, defeating the memoization entirely.

Fixed by having both callbacks read `itemsRef.current` (a ref this 
file already keeps in sync with `items`, used the same way at two 
other call sites) instead of closing over `items` directly, with 
empty dependency arrays. Same pattern the file already uses 
elsewhere for consistency.

**Verified with React DevTools Profiler** (screenshots attached): 
before the itemsRef fix, every commit during a 7-file transfer 
showed all 7 ItemRow entries re-rendering. After the fix, each 
commit shows only the single row whose progress actually changed.

Manually tested: send/receive still works correctly, cancel and 
download still work per-row.
<img width="1361" height="655" alt="Screenshot 2026-07-20 092842" src="https://github.com/user-attachments/assets/9cb603cd-b5bb-4a93-adab-12308d70956b" />
<img width="1363" height="650" alt="Screenshot 2026-07-20 092855" src="https://github.com/user-attachments/assets/7ed9776b-deb3-4908-986c-9fb9c5ae6c41" />
<img width="1359" height="612" alt="Screenshot 2026-07-20 092909" src="https://github.com/user-attachments/assets/c65b036b-3fce-4706-8a59-563efc5657e8" />
<img width="1364" height="650" alt="Screenshot 2026-07-20 092926" src="https://github.com/user-attachments/assets/b55f570f-ed28-4906-a791-9d166dc4ed8a" />
<img width="1364" height="647" alt="Screenshot 2026-07-20 092941" src="https://github.com/user-attachments/assets/add5cf93-143a-48bc-b575-744a2b73b242" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced unnecessary updates to transfer tray rows while other items’ progress changes.
  * Improved transfer action responsiveness during ongoing progress updates.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->