### PR TITLE
Add clipboard fallback and failure feedback for insecure origins

### DIFF
--- a/web/src/brand/BrandKit.tsx
+++ b/web/src/brand/BrandKit.tsx
@@ -2,6 +2,7 @@ import { useState, type ReactNode } from "react";
 import { navigate } from "../router";
 import WarpLogo from "../WarpLogo";
 import { useIsMobile } from "../lib/useIsMobile";
+import { copyToClipboard } from "../lib/copyToClipboard";
 
 /**
  * BrandKit — the "/brand" press / brand-kit page.
@@ -299,16 +300,19 @@ const SWATCHES: { name: string; hex: string }[] = [
 
 function Swatch({ name, hex }: { name: string; hex: string }) {
   const [copied, setCopied] = useState(false);
+  const [copyFailed, setCopyFailed] = useState(false);
   const copy = () => {
-    const res = navigator.clipboard?.writeText(hex);
-    if (res) {
-      res
-        .then(() => {
-          setCopied(true);
-          window.setTimeout(() => setCopied(false), 1200);
-        })
-        .catch(() => {});
-    }
+    void copyToClipboard(hex).then((ok) => {
+      if (ok) {
+        setCopied(true);
+        setCopyFailed(false);
+        window.setTimeout(() => setCopied(false), 1200);
+      } else {
+        setCopyFailed(true);
+        setCopied(false);
+        window.setTimeout(() => setCopyFailed(false), 1800);
+      }
+    });
   };
   return (
     <button
@@ -336,11 +340,11 @@ function Swatch({ name, hex }: { name: string; hex: string }) {
             fontSize: "12px",
             letterSpacing: ".04em",
             textTransform: "uppercase",
-            color: copied ? "var(--acc)" : "#6f6a5d",
+            color: copyFailed ? "var(--amb)" : copied ? "var(--acc)" : "#6f6a5d",
             marginTop: "4px",
           }}
         >
-          {copied ? "Copied ✓" : hex}
+          {copyFailed ? "copy failed" : copied ? "Copied ✓" : hex}
         </div>
       </div>
     </button>

--- a/web/src/lib/copyToClipboard.ts
+++ b/web/src/lib/copyToClipboard.ts
@@ -46,7 +46,8 @@ export async function copyToClipboard(text: string): Promise<boolean> {
     textarea.focus();
     textarea.select();
     textarea.setSelectionRange(0, textarea.value.length);
-    // eslint-disable-next-line deprecation/deprecation -- only fallback left for insecure origins
+    // execCommand is deprecated but remains the only working fallback on
+    // insecure origins where the Clipboard API is unavailable.
     const ok = document.execCommand("copy");
     return ok;
   } catch {

--- a/web/src/lib/copyToClipboard.ts
+++ b/web/src/lib/copyToClipboard.ts
@@ -1,0 +1,58 @@
+/**
+ * Copy text to the clipboard, with a fallback for insecure origins
+ * (plain http:// on a LAN self-host, where navigator.clipboard is
+ * undefined and the Clipboard API throws or doesn't exist at all).
+ *
+ * Returns true on success, false on failure — never throws, so
+ * callers can drive UI state off the boolean instead of a silent
+ * no-op.
+ */
+export async function copyToClipboard(text: string): Promise<boolean> {
+  if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // Fall through to the execCommand fallback below — some browsers
+      // expose navigator.clipboard but still throw on insecure origins
+      // or without a user-activation context.
+    }
+  }
+
+  if (typeof document === "undefined") return false;
+
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  // Keep it out of the visible layout and off-screen, but still
+  // selectable/focusable — some browsers refuse to copy from a
+  // display:none or zero-size element.
+  textarea.style.position = "fixed";
+  textarea.style.top = "0";
+  textarea.style.left = "0";
+  textarea.style.width = "1px";
+  textarea.style.height = "1px";
+  textarea.style.padding = "0";
+  textarea.style.border = "none";
+  textarea.style.outline = "none";
+  textarea.style.boxShadow = "none";
+  textarea.style.background = "transparent";
+  textarea.style.opacity = "0";
+  textarea.setAttribute("readonly", "");
+
+  document.body.appendChild(textarea);
+  const previousFocus = document.activeElement as HTMLElement | null;
+
+  try {
+    textarea.focus();
+    textarea.select();
+    textarea.setSelectionRange(0, textarea.value.length);
+    // eslint-disable-next-line deprecation/deprecation -- only fallback left for insecure origins
+    const ok = document.execCommand("copy");
+    return ok;
+  } catch {
+    return false;
+  } finally {
+    document.body.removeChild(textarea);
+    previousFocus?.focus?.();
+  }
+}

--- a/web/src/transfer/SessionView.tsx
+++ b/web/src/transfer/SessionView.tsx
@@ -18,6 +18,7 @@
 import { memo, useRef, useState } from "react";
 import type { CSSProperties } from "react";
 import { formatBytes, type OfferItem, type TransferItem } from "../lib/warp/transfer";
+import { copyToClipboard } from "../lib/copyToClipboard";
 import type { Connection } from "../lib/warp/useWarpTransfer";
 
 const MONO = "'JetBrains Mono',monospace";
@@ -121,6 +122,7 @@ const ItemRow = memo(function ItemRow({
   peerLabel?: string;
 }) {
   const [copied, setCopied] = useState(false);
+  const [copyFailed, setCopyFailed] = useState(false);
   const col = statusColor(item.status);
   // "reconnecting" holds the bar at its last % and shows RESUMING; it's still an
   // active, cancellable transfer, so it renders like transferring but labeled.
@@ -140,12 +142,15 @@ const ItemRow = memo(function ItemRow({
 
   const copyText = async () => {
     if (!item.text) return;
-    try {
-      await navigator.clipboard.writeText(item.text);
+    const ok = await copyToClipboard(item.text);
+    if (ok) {
       setCopied(true);
+      setCopyFailed(false);
       setTimeout(() => setCopied(false), 1600);
-    } catch {
-      /* clipboard blocked */
+    } else {
+      setCopyFailed(true);
+      setCopied(false);
+      setTimeout(() => setCopyFailed(false), 2200);
     }
   };
 
@@ -289,7 +294,7 @@ const ItemRow = memo(function ItemRow({
               padding: "7px 14px",
               background: "rgba(239,233,218,.03)",
               border: `1px solid ${HAIRLINE}`,
-              color: copied ? "var(--acc)" : "#a8a293",
+              color: copyFailed ? "var(--amb)" : copied ? "var(--acc)" : "#a8a293",
               fontFamily: MONO,
               fontSize: "11px",
               letterSpacing: ".06em",
@@ -297,7 +302,7 @@ const ItemRow = memo(function ItemRow({
               cursor: "pointer",
             }}
           >
-            {copied ? "✓ copied" : "⧉ copy"}
+            {copyFailed ? "✕ copy failed" : copied ? "✓ copied" : "⧉ copy"}
           </button>
         </div>
       )}

--- a/web/src/transfer/TransferFlow.tsx
+++ b/web/src/transfer/TransferFlow.tsx
@@ -6,6 +6,7 @@ import WarpLogo from "../WarpLogo";
 import { useWarpTransfer, type Connection } from "../lib/warp/useWarpTransfer";
 import { formatBytes } from "../lib/warp/transfer";
 import { useIsMobile } from "../lib/useIsMobile";
+import { copyToClipboard } from "../lib/copyToClipboard";
 import { AcceptModal, SessionView } from "./SessionView";
 
 /**
@@ -650,6 +651,7 @@ function PairStep({
   isMobile: boolean;
 }) {
   const [copied, setCopied] = useState(false);
+  const [copyFailed, setCopyFailed] = useState(false);
   const [qrSvg, setQrSvg] = useState<string>("");
   const canShare = typeof navigator !== "undefined" && typeof navigator.share === "function";
 
@@ -670,12 +672,15 @@ function PairStep({
 
   const copy = async () => {
     if (!shareUrl) return;
-    try {
-      await navigator.clipboard.writeText(shareUrl);
+    const ok = await copyToClipboard(shareUrl);
+    if (ok) {
       setCopied(true);
+      setCopyFailed(false);
       setTimeout(() => setCopied(false), 1800);
-    } catch {
-      /* clipboard blocked */
+    } else {
+      setCopyFailed(true);
+      setCopied(false);
+      setTimeout(() => setCopyFailed(false), 2400);
     }
   };
 
@@ -867,9 +872,21 @@ function PairStep({
               type="button"
               className="warp-share"
               onClick={copy}
-              style={isMobile ? { ...shareBtn, display: "block", textAlign: "center" } : shareBtn}
+              style={
+                isMobile
+                  ? {
+                      ...shareBtn,
+                      display: "block",
+                      textAlign: "center",
+                      color: copyFailed ? "var(--amb)" : copied ? "var(--acc)" : shareBtn.color,
+                    }
+                  : {
+                      ...shareBtn,
+                      color: copyFailed ? "var(--amb)" : copied ? "var(--acc)" : shareBtn.color,
+                    }
+              }
             >
-              {copied ? "✓ copied!" : "⧉ Copy link"}
+              {copyFailed ? "✕ copy failed" : copied ? "✓ copied!" : "⧉ Copy link"}
             </button>
             {canShare && (
               <button


### PR DESCRIPTION
Closes #82

Added a shared helper, web/src/lib/copyToClipboard.ts, returning 
Promise<boolean>: tries navigator.clipboard.writeText, falls back to 
a hidden textarea + document.execCommand("copy") when the Clipboard 
API is unavailable or throws (e.g. on plain http:// self-hosts). No 
new dependencies.

Switched all three call sites to the shared helper:
- TransferFlow.tsx — Copy link on the pair screen
- SessionView.tsx — copy a received text snippet
- BrandKit.tsx — copy a hex color token

On success, behavior is unchanged (Copied state as before). On 
failure, each button now shows a visible failure state using 
var(--amb) — the same amber this codebase already uses for warnings 
(e.g. the "Channel failed" panel) — instead of a silent no-op.

Verified: pnpm --filter @warp/web build passes clean. Manually 
tested all three copy buttons work normally on localhost (secure 
context, unchanged happy path).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved copy-to-clipboard reliability across brand color swatches, transfer item snippets, and share links.
  * Added a safe fallback method for environments where the Clipboard API isn’t available or copy is blocked.
  * Copy actions now show clear status feedback for both success and failure (including updated labels and colors), and automatically reset after brief timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->