### PR TITLE
fix(peer): reject pending offers when channel closes

### DIFF
--- a/web/src/lib/warp/peer.check.mjs
+++ b/web/src/lib/warp/peer.check.mjs
@@ -32,7 +32,9 @@ class FakeChannel extends EventTarget {
     });
   }
   close() {
+    if (this.readyState === "closed") return;
     this.readyState = "closed";
+    this.dispatchEvent(new Event("close"));
   }
 }
 
@@ -247,4 +249,120 @@ await receiver.handleSignal("A", { kind: "cancel", id: liveId });
 assert.equal(cancelledCount, 1, "a redundant cancel (in-band/out-of-band dup) is a no-op");
 await send4; // sender resolves even though the item was cancelled
 
-console.log("OK: offer/accept stream + decline gating + disk-stream + instant-cancel round-trip passed");
+// --- channel closes while an offer is awaiting accept/decline -------------
+// The public promise must reject promptly so useWarpTransfer's existing catch
+// can stage the files for salvage/re-offer. A timeout is the historical bug.
+const droppedSender = new WarpPeer(sig, "D", true);
+const droppedReceiver = new WarpPeer(sig, "C", false);
+const droppedSenderChannel = droppedSender.pc.localChannel;
+const droppedReceiverChannel = new FakeChannel();
+droppedSenderChannel.peer = droppedReceiverChannel;
+droppedReceiverChannel.peer = droppedSenderChannel;
+droppedReceiver.pc.dispatchEvent(
+  Object.assign(new Event("datachannel"), { channel: droppedReceiverChannel }),
+);
+
+const droppedOfferSeen = waitFor(droppedReceiver, "incoming-offer");
+const droppedOffer = droppedSender.offerFiles([file]);
+await droppedOfferSeen; // proves the batch is registered and awaiting a response
+droppedSenderChannel.close();
+const droppedOutcome = await Promise.race([
+  droppedOffer.then(
+    () => ({ kind: "resolved" }),
+    (reason) => ({ kind: "rejected", reason }),
+  ),
+  new Promise((resolve) => setTimeout(() => resolve({ kind: "timeout" }), 100)),
+]);
+assert.equal(
+  droppedOutcome.kind,
+  "rejected",
+  "offerFiles rejects instead of hanging when the channel closes before accept/decline",
+);
+assert.equal(droppedOutcome.reason?.message, "channel-closed", "channel closure stays distinct from decline");
+
+async function checkPendingOfferTrigger(label, trigger) {
+  const triggerSender = new WarpPeer(sig, `${label}-remote`, true);
+  const triggerReceiver = new WarpPeer(sig, `${label}-local`, false);
+  const triggerSenderChannel = triggerSender.pc.localChannel;
+  const triggerReceiverChannel = new FakeChannel();
+  triggerSenderChannel.peer = triggerReceiverChannel;
+  triggerReceiverChannel.peer = triggerSenderChannel;
+  triggerReceiver.pc.dispatchEvent(
+    Object.assign(new Event("datachannel"), { channel: triggerReceiverChannel }),
+  );
+  const triggerOfferSeen = waitFor(triggerReceiver, "incoming-offer");
+  const triggerOffer = triggerSender.offerFiles([file]);
+  await triggerOfferSeen;
+  trigger(triggerSender, triggerSenderChannel);
+  const outcome = await Promise.race([
+    triggerOffer.then(
+      () => ({ kind: "resolved" }),
+      (reason) => ({ kind: "rejected", reason }),
+    ),
+    new Promise((resolve) => setTimeout(() => resolve({ kind: "timeout" }), 100)),
+  ]);
+  assert.equal(outcome.kind, "rejected", `${label} rejects a pending offer`);
+  assert.equal(outcome.reason?.message, "channel-closed", `${label} uses channel-closed`);
+}
+
+await checkPendingOfferTrigger("channel error", (_peer, channel) => {
+  channel.dispatchEvent(new Event("error"));
+});
+await checkPendingOfferTrigger("explicit close", (peer) => {
+  peer.close();
+});
+
+// The channel can also die while an image thumbnail is being prepared, before
+// the batch enters `outgoing`. Registration must notice that already-dead state
+// instead of waiting for an error/close event that has already happened.
+const savedDocument = globalThis.document;
+const savedCreateImageBitmap = globalThis.createImageBitmap;
+let thumbnailStarted;
+const thumbnailStartedPromise = new Promise((resolve) => {
+  thumbnailStarted = resolve;
+});
+let finishThumbnail;
+globalThis.document = {
+  createElement() {
+    return {
+      width: 0,
+      height: 0,
+      getContext: () => ({ drawImage() {} }),
+      toDataURL: () => "data:image/jpeg;base64,AA==",
+    };
+  },
+};
+globalThis.createImageBitmap = async () => {
+  thumbnailStarted();
+  return await new Promise((resolve) => {
+    finishThumbnail = () => resolve({ width: 1, height: 1, close() {} });
+  });
+};
+
+const delayedSender = new WarpPeer(sig, "F", true);
+const image = new Blob(["pixels"], { type: "image/png" });
+image.name = "pixel.png";
+image.slice = Blob.prototype.slice;
+const delayedOffer = delayedSender.offerFiles([image]);
+await thumbnailStartedPromise;
+delayedSender.pc.localChannel.close();
+finishThumbnail();
+const delayedOutcome = await Promise.race([
+  delayedOffer.then(
+    () => ({ kind: "resolved" }),
+    (reason) => ({ kind: "rejected", reason }),
+  ),
+  new Promise((resolve) => setTimeout(() => resolve({ kind: "timeout" }), 100)),
+]);
+globalThis.document = savedDocument;
+globalThis.createImageBitmap = savedCreateImageBitmap;
+assert.equal(
+  delayedOutcome.kind,
+  "rejected",
+  "offerFiles rejects when the channel closes before pending-batch registration",
+);
+assert.equal(delayedOutcome.reason?.message, "channel-closed", "registration-time closure uses channel-closed");
+
+console.log(
+  "OK: offer/accept stream + decline gating + disk-stream + instant-cancel + pending-offer channel-close rejection passed",
+);

--- a/web/src/lib/warp/peer.ts
+++ b/web/src/lib/warp/peer.ts
@@ -161,9 +161,9 @@ type Listener<K extends keyof PeerEvents> = PeerEvents[K];
 interface OutgoingBatch {
   batchId: string;
   files: File[];
-  /** Resolves (with the receiver's per-file resume offsets) on accept; rejects on decline. */
+  /** Resolves on accept; rejects when the receiver declines or the channel closes. */
   resolve: (resume?: Record<string, number>) => void;
-  reject: (reason: "declined") => void;
+  reject: (reason: "declined" | Error) => void;
   /** Set true the moment the receiver responds, so a late dup is ignored. */
   settled: boolean;
   /** Per-file resumeToken (id -> token) so a re-offer reuses the same token. */
@@ -476,12 +476,14 @@ export class WarpPeer {
 
     ch.addEventListener("open", () => this.emit("connected"));
     ch.addEventListener("error", () => {
+      this.rejectPendingOffers();
       if (!this.disposed) this.emit("error", "channel-error");
     });
     // SCTP is gone for good once the channel closes (an ICE restart can't revive
     // a closed channel). Surface it so the hook can salvage + rebuild the peer.
     ch.addEventListener("close", () => {
       this.clearRestartTimer();
+      this.rejectPendingOffers();
       if (!this.disposed) this.emit("error", "disconnected");
     });
     ch.addEventListener("message", (ev) => this.onMessage(ev.data));
@@ -550,6 +552,10 @@ export class WarpPeer {
       this.emit("transfer", { ...item });
     }
 
+    // Thumbnail generation above is asynchronous. The channel may have closed
+    // before this batch could register, after its final close/error event.
+    if (ch.readyState !== "open") throw new Error("channel-closed");
+
     // Register the pending batch BEFORE sending, so an instant accept/decline finds it.
     const accepted = new Promise<Record<string, number> | undefined>((resolve, reject) => {
       this.outgoing.set(batchId, { batchId, files, resolve, reject, settled: false, tokens });
@@ -560,8 +566,10 @@ export class WarpPeer {
     let resume: Record<string, number> | undefined;
     try {
       resume = await accepted;
-    } catch {
-      // Declined: mark every item declined and bail (channel stays open).
+    } catch (reason) {
+      // A real decline is terminal for this offer. Channel closure stays
+      // salvageable: leave the items unfinished and reject to the hook.
+      if (reason !== "declined") throw reason;
       for (const id of ids) this.markStatus(id, "declined");
       return;
     }
@@ -858,6 +866,16 @@ export class WarpPeer {
     ch.send(JSON.stringify(msg));
   }
 
+  /** Reject every still-pending local offer exactly once on transport death. */
+  private rejectPendingOffers(): void {
+    for (const [batchId, batch] of this.outgoing) {
+      if (batch.settled) continue;
+      batch.settled = true;
+      this.outgoing.delete(batchId);
+      batch.reject(new Error("channel-closed"));
+    }
+  }
+
   /** Update an item's status by id and re-emit. */
   private markStatus(id: string, status: TransferItem["status"]): void {
     const item = this.items.get(id);
@@ -1073,6 +1091,7 @@ export class WarpPeer {
   // ---- teardown ------------------------------------------------------------
 
   close(): void {
+    this.rejectPendingOffers();
     this.disposed = true;
     this.clearRestartTimer();
     try {


### PR DESCRIPTION
## What & why

`offerFiles()` could wait forever when its data channel closed before an accept or decline arrived. Reject pending offers on channel error, channel close, and explicit peer close, including a close during asynchronous thumbnail preparation, so the existing salvage and re-offer path can run. Receiver declines keep their existing behavior.

Closes #112

## Type

- [ ] feat
- [x] fix
- [ ] docs / chore / refactor / test / perf

## Checklist

- [x] `pnpm lint && pnpm typecheck` pass locally (0 lint errors; 7 existing warnings in untouched files)
- [x] `pnpm --filter @warp/web build` is green (web changes)
- [x] `pnpm --filter @warp/server test` passes
- [x] Engine changes: `peer.check.mjs` and `useWarpTransfer.check.mjs` pass, including pending-offer close and salvage coverage

### Hard constraints (see [CONTRIBUTING.md](../CONTRIBUTING.md#hard-constraints-the-soul-of-the-project))

- [x] No new recurring-cost infrastructure — no TURN, database, storage, or paid API ($0, no card, forever)
- [x] Still STUN-only — no relay in the file path; NAT failure stays an honest error
- [x] The signaling server still never reads, stores, or understands file contents
- [x] `SEND_HIGH_WATER` in `peer.ts` is untouched and remains well below 16 MiB
- [x] Transient network drops still recover; channel closure now reaches the existing salvage/re-offer path

## Screenshots / recordings

Not applicable: this is an engine-only change with no UI behavior or styling changes. The fake-channel harness covers close after offer, channel error, explicit close, and close during thumbnail preparation; no browser or device runtime validation is claimed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pending file offers now fail promptly when the data channel or peer closes.
  * Prevented file offers from remaining unresolved after channel errors or closure during thumbnail preparation.
  * Improved error reporting so channel closures are clearly distinguished from declined offers.
  * Ensured repeated close events are handled safely without duplicate processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a hang in `offerFiles()` where a closed data channel left the pending-offer promise unresolved forever. Three new rejection triggers are added: channel `error` event, channel `close` event, and explicit `peer.close()`; a post-thumbnail readyState guard handles the race where the channel dies during async bitmap generation before the batch is registered.

- `rejectPendingOffers()` iterates `this.outgoing`, marks each unsettled batch as settled, deletes it, and rejects with `new Error("channel-closed")`.
- The `offerFiles` catch block now re-throws anything that is not the literal string `"declined"`, letting the hook's existing salvage path run on channel-closed errors while still swallowing genuine receiver declines internally.
- `peer.check.mjs` gains four new test cases (direct close, channel error, explicit peer close, and close-during-thumbnail), and `FakeChannel.close()` is fixed to dispatch a synchronous `"close"` event with an idempotent guard.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge. The fix is well-scoped: it adds a new private method and three call sites, with no changes to the wire protocol, channel lifecycle ownership, or decline behavior.

The three rejection paths (channel error, channel close, explicit peer close) are each covered by a dedicated test; the post-thumbnail readyState guard is tested via a synthetic async pause. The rejectPendingOffers() method is idempotent — it checks batch.settled and deletes from outgoing before calling reject — so double-invocation (e.g. error followed by close) is harmless. The catch-block change correctly re-throws non-decline errors while leaving the existing decline handling untouched. No wire protocol or data-path code is changed.

No files require special attention. The only behavioral surface not exercised in peer.check.mjs is the hook-level salvage path in useWarpTransfer.ts, but the PR notes that useWarpTransfer.check.mjs covers this separately.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/src/lib/warp/peer.ts | Adds rejectPendingOffers() called from channel error/close handlers and close(); inserts a post-thumbnail readyState guard in offerFiles(); updates the catch block to re-throw non-decline errors. Logic is correct and idempotent. |
| web/src/lib/warp/peer.check.mjs | FakeChannel.close() now dispatches a synchronous close event with an idempotent guard. Four new test scenarios cover the direct-close, channel-error, explicit-peer-close, and close-during-thumbnail paths. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Hook as useWarpTransfer
    participant Peer as WarpPeer
    participant Ch as RTCDataChannel

    Hook->>Peer: offerFiles(files)
    Note over Peer: makeThumb() async
    Ch-->>Peer: close / error event
    Peer->>Peer: rejectPendingOffers()
    Peer--xHook: offerFiles() rejects Error(channel-closed)
    Hook->>Hook: salvage + re-offer path

    Note over Peer,Ch: Normal decline unchanged
    Ch-->>Peer: decline message
    Peer->>Peer: markStatus(ids, declined)
    Peer-->>Hook: offerFiles() resolves normally
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(peer): reject pending offers when ch..."](https://github.com/ishannaik/warp/commit/f458da5ebcef938433d4bc43e23625336c133de0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46262745)</sub>

<!-- /greptile_comment -->