### PR TITLE
docs: add signaling server threat model

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,7 @@
 # Security Policy
 
 Warp moves people's files, so security reports are taken seriously.
+For the system trust boundaries and what the signaling server can and cannot access, see [Threat Model](./docs/THREAT-MODEL.md).
 
 ## Reporting a vulnerability
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,5 +1,7 @@
 # Warp architecture
 
+For the security trust boundary of the signaling server, see [Threat Model](./THREAT-MODEL.md).
+
 How a file gets from one browser to another without any server ever touching it. This is the deep tour for new contributors — everything here cites the real files and functions, so you can read along in the code.
 
 **The one-paragraph version:** a tiny Cloudflare Worker introduces two browsers to each other over WebSocket (the *signaling* plane), the browsers negotiate a direct, encrypted WebRTC data channel (the *data* plane), and files stream peer-to-peer over that channel using a small JSON-control + binary-chunk wire protocol with backpressure, accept-gating, instant cancel, and byte-exact resume. The server never sees a file byte — it can't, by construction.

--- a/docs/THREAT-MODEL.md
+++ b/docs/THREAT-MODEL.md
@@ -10,7 +10,7 @@ The signaling server only processes the information required to establish a peer
 - WebRTC signaling data (`signal.data`), including SDP and ICE messages
 - Connection and disconnection timing
 - The connecting public IP address (grouped to a /64 prefix for IPv6 to support nearby device discovery)
-
+- Device display names (when devices use nearby discovery)
 The signaling server relays signaling messages between peers without interpreting or modifying their contents.
 
 ### What the signaling server cannot see
@@ -23,7 +23,7 @@ As a result, the signaling server cannot inspect:
 - File contents
 - Data transferred over the WebRTC data channel
 
-For additional background on the networking model, see `docs/theory-content.md`.
+For additional background on the networking model, see [theory-content.md](./theory-content.md).
 
 ---
 

--- a/docs/THREAT-MODEL.md
+++ b/docs/THREAT-MODEL.md
@@ -1,0 +1,42 @@
+# Threat Model
+
+This document describes Warp's trust boundaries and what different parts of the system can and cannot access.
+
+## Signaling Server Trust Boundary
+
+### What the signaling server can see
+
+The signaling server only processes the information required to establish a peer-to-peer connection. This includes:
+
+- Room codes
+- Peer IDs
+- WebRTC signaling data (`signal.data`), including SDP and ICE messages
+- Connection and disconnection timing
+
+The signaling server relays signaling messages between peers without interpreting or modifying their contents.
+
+### What the signaling server cannot see
+
+The signaling server never receives or stores:
+
+- File bytes
+- File contents
+- Data transferred over the WebRTC data channel
+
+After the WebRTC connection is established, file data is transferred directly between peers over an encrypted `RTCDataChannel`. The signaling server is not part of the data path and never receives transferred file data.
+
+For additional background on the networking model, see `docs/theory-content.md`.
+
+---
+
+## Malicious Peer
+
+(To be documented.)
+
+## Room Code Entropy
+
+(To be documented.)
+
+## Client-side Attack Surface
+
+(To be documented.)

--- a/docs/THREAT-MODEL.md
+++ b/docs/THREAT-MODEL.md
@@ -1,3 +1,4 @@
+# Threat Model
 ## Signaling Server Trust Boundary
 
 ### What the signaling server can see
@@ -8,15 +9,13 @@ The signaling server only processes the information required to establish a peer
 - Peer IDs
 - WebRTC signaling data (`signal.data`), including SDP and ICE messages
 - Connection and disconnection timing
-<<<<<<< HEAD
-=======
 - The connecting public IP address (grouped to a /64 prefix for IPv6 to support nearby device discovery)
 
 The signaling server relays signaling messages between peers without interpreting or modifying their contents.
 
 ### What the signaling server cannot see
 
-After the WebRTC connection is established, file data is transferred directly between peers over an encrypted `RTCDataChannel`. The signaling server is not part of the data path and does not receive the transferred file bytes.
+After the WebRTC connection is established, file data is transferred directly between peers over an encrypted `RTCDataChannel`. The signaling server is not part of the data path and never receives or stores transferred file bytes.
 
 As a result, the signaling server cannot inspect:
 

--- a/docs/THREAT-MODEL.md
+++ b/docs/THREAT-MODEL.md
@@ -12,6 +12,9 @@ The signaling server only processes the information required to establish a peer
 - Peer IDs
 - WebRTC signaling data (`signal.data`), including SDP and ICE messages
 - Connection and disconnection timing
+<<<<<<< HEAD
+=======
+- The connecting public IP address (grouped to a /64 prefix for IPv6 to support nearby device discovery)
 
 The signaling server relays signaling messages between peers without interpreting or modifying their contents.
 

--- a/docs/THREAT-MODEL.md
+++ b/docs/THREAT-MODEL.md
@@ -1,7 +1,3 @@
-# Threat Model
-
-This document describes Warp's trust boundaries and what different parts of the system can and cannot access.
-
 ## Signaling Server Trust Boundary
 
 ### What the signaling server can see
@@ -20,13 +16,13 @@ The signaling server relays signaling messages between peers without interpretin
 
 ### What the signaling server cannot see
 
-The signaling server never receives or stores:
+After the WebRTC connection is established, file data is transferred directly between peers over an encrypted `RTCDataChannel`. The signaling server is not part of the data path and does not receive the transferred file bytes.
+
+As a result, the signaling server cannot inspect:
 
 - File bytes
 - File contents
 - Data transferred over the WebRTC data channel
-
-After the WebRTC connection is established, file data is transferred directly between peers over an encrypted `RTCDataChannel`. The signaling server is not part of the data path and never receives transferred file data.
 
 For additional background on the networking model, see `docs/theory-content.md`.
 


### PR DESCRIPTION
Closes #157

## Summary
- Added `docs/THREAT-MODEL.md` with the signaling server trust boundary
- Documented what the signaling server can and cannot access
- Linked the new document from `SECURITY.md` and `docs/ARCHITECTURE.md`
- Added placeholder sections for future threat model documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a new threat model describing the signaling server’s trust boundary and what it can observe (room codes, peer identifiers, WebRTC signaling payloads, connection timing, and public IP details).
  - Clarified that signaling is relayed without interpreting/modifying payload contents, and that file data is exchanged directly over encrypted data channels after connection setup.
  - Added cross-references to the threat model from the security and architecture documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds `docs/THREAT-MODEL.md` documenting the signaling server's trust boundary and cross-links it from `SECURITY.md` and `docs/ARCHITECTURE.md`. The content accurately reflects the server's role as a dumb relay that sees WebRTC handshake metadata but never file bytes.

- **New threat model**: Documents what the signaling server can observe (room codes, peer IDs, SDP/ICE payloads, timing, public IP, display names) and what it cannot (file bytes, data channel contents), consistent with the architecture described in `CLAUDE.md` and `ARCHITECTURE.md`.
- **Cross-references**: Both `SECURITY.md` (repo root) and `docs/ARCHITECTURE.md` receive a one-line link; relative paths in both are correct.
- **Placeholder sections**: Stubs for \"Malicious Peer\", \"Room Code Entropy\", and \"Client-side Attack Surface\" are included for future expansion.
</details>

<h3>Confidence Score: 5/5</h3>

Documentation-only change; no runtime code is modified and all relative links resolve correctly.

The change adds a new Markdown document and two cross-reference lines. The threat model content is consistent with the actual server implementation described in CLAUDE.md and ARCHITECTURE.md. No code paths are affected.

**Files Needing Attention:** docs/THREAT-MODEL.md has a minor Markdown formatting gap (missing blank line before a trailing sentence) and no trailing newline, but neither affects functionality.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/THREAT-MODEL.md | New threat model document covering the signaling server trust boundary; has a minor Markdown formatting issue (missing blank line between list and following paragraph) and still lacks a trailing newline. |
| SECURITY.md | Adds a one-line cross-reference to the new threat model; link path is correct relative to repo root. |
| docs/ARCHITECTURE.md | Adds a one-line cross-reference to the threat model at the top of the architecture doc; link path resolves correctly within the docs/ directory. |

<sub>Reviews (3): Last reviewed commit: ["docs: improve threat model references"](https://github.com/ishannaik/warp/commit/2e2dbe46839877c384adecae2e943c6b5be5edb8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47391820)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/ishannaik/github/Ishannaik/warp/-/custom-context?memory=575c40ec-32b8-4814-a2b7-1ced5808ec85))

<!-- /greptile_comment -->