### PR TITLE
fix(peer): cap text snippet payloads

### DIFF
--- a/web/src/lib/warp/peer.check.mjs
+++ b/web/src/lib/warp/peer.check.mjs
@@ -138,6 +138,38 @@ assert.equal(text, "hello wrap world", "received blob reassembles to the sent by
 
 await sendPromise; // sender resolves only after streaming completes
 
+// text snippets stay inline, but oversized snippets must never hit send().
+let textSendTransfer = null;
+const offTextTransfer = sender.on("transfer", (item) => {
+  if (item.kind === "text" && item.direction === "send") textSendTransfer = item;
+});
+const textSeen = waitFor(receiver, "text-received");
+sender.sendText("short note");
+const textReceived = await textSeen;
+assert.equal(textReceived.text, "short note", "text snippets arrive over the data channel");
+assert.equal(textSendTransfer?.size, new Blob(["short note"]).size, "text send item records byte size");
+offTextTransfer();
+
+let oversizedSent = false;
+let oversizedTransfer = false;
+const rawTextSend = sCh.send.bind(sCh);
+sCh.send = (d) => {
+  oversizedSent = true;
+  return rawTextSend(d);
+};
+const offOversizedTransfer = sender.on("transfer", (item) => {
+  if (item.kind === "text") oversizedTransfer = true;
+});
+assert.throws(
+  () => sender.sendText("x".repeat(64 * 1024 + 1)),
+  /text-too-large/,
+  "oversized text snippets are refused before sending",
+);
+offOversizedTransfer();
+sCh.send = rawTextSend;
+assert.equal(oversizedSent, false, "oversized text does not call channel.send()");
+assert.equal(oversizedTransfer, false, "oversized text does not create a transfer item");
+
 // decline gating: a second offer that gets declined must send no item to done.
 const offer2Seen = waitFor(receiver, "incoming-offer");
 const send2 = sender.offerFiles([file]);
@@ -364,5 +396,5 @@ assert.equal(
 assert.equal(delayedOutcome.reason?.message, "channel-closed", "registration-time closure uses channel-closed");
 
 console.log(
-  "OK: offer/accept stream + decline gating + disk-stream + instant-cancel + pending-offer channel-close rejection passed",
+  "OK: offer/accept stream + text size cap + decline gating + disk-stream + instant-cancel + pending-offer channel-close rejection passed",
 );

--- a/web/src/lib/warp/peer.check.mjs
+++ b/web/src/lib/warp/peer.check.mjs
@@ -138,21 +138,62 @@ assert.equal(text, "hello wrap world", "received blob reassembles to the sent by
 
 await sendPromise; // sender resolves only after streaming completes
 
-// text snippets stay inline, but oversized snippets must never hit send().
+// text snippets stay inline, but oversized serialized frames must never hit send().
+const TEXT_SNIPPET_MAX_BYTES = 64 * 1024;
+const frameBytes = (id, text) => new TextEncoder().encode(JSON.stringify({ t: "text", id, text })).byteLength;
+const frameRoomForText = (id) => TEXT_SNIPPET_MAX_BYTES - frameBytes(id, "");
+const fixedRandom = () => 0.123456789;
+const fixedTextId = fixedRandom().toString(36).slice(2, 10);
+function withFixedIds(fn) {
+  const savedRandom = Math.random;
+  Math.random = fixedRandom;
+  try {
+    return fn();
+  } finally {
+    Math.random = savedRandom;
+  }
+}
+
 let textSendTransfer = null;
 const offTextTransfer = sender.on("transfer", (item) => {
   if (item.kind === "text" && item.direction === "send") textSendTransfer = item;
 });
 const textSeen = waitFor(receiver, "text-received");
+const textFrames = [];
+const rawTextSend = sCh.send.bind(sCh);
+sCh.send = (d) => {
+  if (typeof d === "string") {
+    const msg = JSON.parse(d);
+    if (msg.t === "text") textFrames.push(d);
+  }
+  return rawTextSend(d);
+};
 sender.sendText("short note");
 const textReceived = await textSeen;
 assert.equal(textReceived.text, "short note", "text snippets arrive over the data channel");
 assert.equal(textSendTransfer?.size, new Blob(["short note"]).size, "text send item records byte size");
 offTextTransfer();
+assert.ok(
+  new TextEncoder().encode(textFrames.at(-1)).byteLength <= TEXT_SNIPPET_MAX_BYTES,
+  "normal text frame stays within the 64 KiB wire cap",
+);
 
+const boundarySeen = waitFor(receiver, "text-received");
+const boundaryText = "x".repeat(frameRoomForText(fixedTextId));
+withFixedIds(() => sender.sendText(boundaryText));
+const boundaryReceived = await boundarySeen;
+const boundaryFrame = textFrames.at(-1);
+assert.equal(boundaryReceived.text.length, boundaryText.length, "boundary-size text is still delivered");
+assert.equal(
+  new TextEncoder().encode(boundaryFrame).byteLength,
+  TEXT_SNIPPET_MAX_BYTES,
+  "boundary-size text serializes to exactly the 64 KiB wire cap",
+);
+sCh.send = rawTextSend;
+
+// Backslash-heavy text can be raw-small but JSON-large; guard the serialized frame.
 let oversizedSent = false;
 let oversizedTransfer = false;
-const rawTextSend = sCh.send.bind(sCh);
 sCh.send = (d) => {
   oversizedSent = true;
   return rawTextSend(d);
@@ -161,9 +202,14 @@ const offOversizedTransfer = sender.on("transfer", (item) => {
   if (item.kind === "text") oversizedTransfer = true;
 });
 assert.throws(
-  () => sender.sendText("x".repeat(64 * 1024 + 1)),
+  () => withFixedIds(() => sender.sendText("x".repeat(frameRoomForText(fixedTextId) + 1))),
   /text-too-large/,
-  "oversized text snippets are refused before sending",
+  "one byte over the serialized frame cap is refused before sending",
+);
+assert.throws(
+  () => sender.sendText("\\".repeat(Math.ceil(TEXT_SNIPPET_MAX_BYTES / 2))),
+  /text-too-large/,
+  "JSON-escaped text is capped by serialized frame bytes, not raw text bytes",
 );
 offOversizedTransfer();
 sCh.send = rawTextSend;

--- a/web/src/lib/warp/peer.ts
+++ b/web/src/lib/warp/peer.ts
@@ -33,6 +33,7 @@
 import type { SignalData, SignalingClient } from "./signaling";
 import {
   LOW_WATER_MARK,
+  TEXT_SNIPPET_MAX_BYTES,
   fileId,
   fileKey,
   newResumeToken,
@@ -629,6 +630,7 @@ export class WarpPeer {
     const id = fileId();
     const batchId = fileId();
     const bytes = new Blob([text]).size;
+    if (bytes > TEXT_SNIPPET_MAX_BYTES) throw new Error("text-too-large");
     const item: TransferItem = {
       id,
       batchId,

--- a/web/src/lib/warp/peer.ts
+++ b/web/src/lib/warp/peer.ts
@@ -37,6 +37,7 @@ import {
   fileId,
   fileKey,
   newResumeToken,
+  textSnippetFrameBytes,
   type ControlMessage,
   type Direction,
   type OfferItem,
@@ -628,9 +629,9 @@ export class WarpPeer {
     const ch = this.channel;
     if (!ch || ch.readyState !== "open") throw new Error("channel-not-open");
     const id = fileId();
-    const batchId = fileId();
+    if (textSnippetFrameBytes(text, id) > TEXT_SNIPPET_MAX_BYTES) throw new Error("text-too-large");
     const bytes = new Blob([text]).size;
-    if (bytes > TEXT_SNIPPET_MAX_BYTES) throw new Error("text-too-large");
+    const batchId = fileId();
     const item: TransferItem = {
       id,
       batchId,

--- a/web/src/lib/warp/transfer.ts
+++ b/web/src/lib/warp/transfer.ts
@@ -22,6 +22,13 @@ export const CHUNK_SIZE = 16 * 1024;
 
 /** Text snippets stay as one JSON control frame; keep them below old SCTP caps. */
 export const TEXT_SNIPPET_MAX_BYTES = 64 * 1024;
+const TEXT_SNIPPET_SIZE_PROBE_ID = "xxxxxxxx";
+const TEXT_FRAME_ENCODER = new TextEncoder();
+
+/** Serialized UTF-8 size of the actual text control frame sent on the wire. */
+export function textSnippetFrameBytes(text: string, id = TEXT_SNIPPET_SIZE_PROBE_ID): number {
+  return TEXT_FRAME_ENCODER.encode(JSON.stringify({ t: "text", id, text })).byteLength;
+}
 
 /**
  * bufferedAmount high-water mark. When the channel's send buffer exceeds this

--- a/web/src/lib/warp/transfer.ts
+++ b/web/src/lib/warp/transfer.ts
@@ -20,6 +20,9 @@
 /** 16 KiB chunk size — the SCTP-friendly sweet spot used across the design copy. */
 export const CHUNK_SIZE = 16 * 1024;
 
+/** Text snippets stay as one JSON control frame; keep them below old SCTP caps. */
+export const TEXT_SNIPPET_MAX_BYTES = 64 * 1024;
+
 /**
  * bufferedAmount high-water mark. When the channel's send buffer exceeds this
  * we stop pumping and wait for `bufferedamountlow` before resuming, so we never

--- a/web/src/transfer/SessionView.tsx
+++ b/web/src/transfer/SessionView.tsx
@@ -410,9 +410,8 @@ function Composer({
   const pickFolder = () => folderInput.current?.click();
 
   const submitText = () => {
-    const t = text.trim();
-    if (!t || textSnippetFrameBytes(t) > TEXT_SNIPPET_MAX_BYTES) return;
-    onSendText(t);
+    if (!canSendText) return;
+    onSendText(trimmedText);
     setText("");
   };
 

--- a/web/src/transfer/SessionView.tsx
+++ b/web/src/transfer/SessionView.tsx
@@ -17,7 +17,13 @@
 
 import { memo, useRef, useState } from "react";
 import type { CSSProperties } from "react";
-import { TEXT_SNIPPET_MAX_BYTES, formatBytes, type OfferItem, type TransferItem } from "../lib/warp/transfer";
+import {
+  TEXT_SNIPPET_MAX_BYTES,
+  formatBytes,
+  textSnippetFrameBytes,
+  type OfferItem,
+  type TransferItem,
+} from "../lib/warp/transfer";
 import { copyToClipboard } from "../lib/copyToClipboard";
 import type { Connection } from "../lib/warp/useWarpTransfer";
 
@@ -396,8 +402,8 @@ function Composer({
   // " to N devices" suffix shown only in a mesh room (>1 connected device).
   const fanout = deviceCount > 1 ? ` to ${deviceCount} devices` : "";
   const trimmedText = text.trim();
-  const textBytes = new Blob([trimmedText]).size;
-  const textTooLarge = textBytes > TEXT_SNIPPET_MAX_BYTES;
+  const frameBytes = textSnippetFrameBytes(trimmedText);
+  const textTooLarge = frameBytes > TEXT_SNIPPET_MAX_BYTES;
   const canSendText = !!trimmedText && !textTooLarge;
 
   const pickFiles = () => fileInput.current?.click();
@@ -405,7 +411,7 @@ function Composer({
 
   const submitText = () => {
     const t = text.trim();
-    if (!t || new Blob([t]).size > TEXT_SNIPPET_MAX_BYTES) return;
+    if (!t || textSnippetFrameBytes(t) > TEXT_SNIPPET_MAX_BYTES) return;
     onSendText(t);
     setText("");
   };
@@ -489,7 +495,7 @@ function Composer({
                 overflowWrap: "anywhere",
               }}
             >
-              Too long to send as text ({formatBytes(textBytes)}). Save it as a .txt file and send that instead.
+              Too long to send as text ({formatBytes(frameBytes)}). Save it as a .txt file and send that instead.
             </div>
           )}
           <button

--- a/web/src/transfer/SessionView.tsx
+++ b/web/src/transfer/SessionView.tsx
@@ -17,7 +17,7 @@
 
 import { memo, useRef, useState } from "react";
 import type { CSSProperties } from "react";
-import { formatBytes, type OfferItem, type TransferItem } from "../lib/warp/transfer";
+import { TEXT_SNIPPET_MAX_BYTES, formatBytes, type OfferItem, type TransferItem } from "../lib/warp/transfer";
 import { copyToClipboard } from "../lib/copyToClipboard";
 import type { Connection } from "../lib/warp/useWarpTransfer";
 
@@ -395,13 +395,17 @@ function Composer({
   const pendingList = pending ?? [];
   // " to N devices" suffix shown only in a mesh room (>1 connected device).
   const fanout = deviceCount > 1 ? ` to ${deviceCount} devices` : "";
+  const trimmedText = text.trim();
+  const textBytes = new Blob([trimmedText]).size;
+  const textTooLarge = textBytes > TEXT_SNIPPET_MAX_BYTES;
+  const canSendText = !!trimmedText && !textTooLarge;
 
   const pickFiles = () => fileInput.current?.click();
   const pickFolder = () => folderInput.current?.click();
 
   const submitText = () => {
     const t = text.trim();
-    if (!t) return;
+    if (!t || new Blob([t]).size > TEXT_SNIPPET_MAX_BYTES) return;
     onSendText(t);
     setText("");
   };
@@ -447,6 +451,8 @@ function Composer({
         {/* text snippet */}
         <div style={{ display: "flex", flexDirection: "column", gap: "10px" }}>
           <textarea
+            aria-invalid={textTooLarge}
+            aria-describedby={textTooLarge ? "text-size-hint" : undefined}
             value={text}
             onChange={(e) => setText(e.target.value)}
             placeholder="…or paste a link / note to send as text"
@@ -471,23 +477,38 @@ function Composer({
               lineHeight: 1.5,
             }}
           />
+          {textTooLarge && (
+            <div
+              id="text-size-hint"
+              role="status"
+              style={{
+                color: "#ef6a3d",
+                fontFamily: MONO,
+                fontSize: "11px",
+                lineHeight: 1.45,
+                overflowWrap: "anywhere",
+              }}
+            >
+              Too long to send as text ({formatBytes(textBytes)}). Save it as a .txt file and send that instead.
+            </div>
+          )}
           <button
             type="button"
-            className={text.trim() ? "warp-cta" : undefined}
+            className={canSendText ? "warp-cta" : undefined}
             onClick={submitText}
-            disabled={!text.trim()}
+            disabled={!canSendText}
             style={{
               alignSelf: isMobile ? "stretch" : "flex-end",
               padding: "11px 22px",
-              background: text.trim() ? "var(--acc)" : "rgba(239,233,218,.12)",
-              color: text.trim() ? "#fff" : "#6f6a5d",
+              background: canSendText ? "var(--acc)" : "rgba(239,233,218,.12)",
+              color: canSendText ? "#fff" : "#6f6a5d",
               border: "none",
               fontFamily: MONO,
               fontSize: "11.5px",
               fontWeight: 600,
               letterSpacing: ".07em",
               textTransform: "uppercase",
-              cursor: text.trim() ? "pointer" : "not-allowed",
+              cursor: canSendText ? "pointer" : "not-allowed",
             }}
           >
             Send text{fanout} →


### PR DESCRIPTION
## What & why

Inline text snippets are sent as one JSON control frame, so a pasted log/base64 blob can exceed the data channel's safe single-message size and kill the session. This keeps that path bounded without changing the wire protocol:

- add a shared `TEXT_SNIPPET_MAX_BYTES` cap at 64 KiB next to the wire constants
- have `WarpPeer.sendText()` reject oversized snippets before creating a tray item or writing to the data channel
- show the same limit in the composer with a visible hint and disabled send button
- cover normal text delivery and the oversized refusal path in `peer.check.mjs`

Closes #81

## Type

- [x] fix
- [ ] feat
- [ ] docs / chore / refactor / test / perf

## Checklist

- [x] `pnpm lint && pnpm typecheck` pass locally (`pnpm lint` has 7 existing warnings, 0 errors)
- [x] `pnpm --filter @warp/web build` is green (web changes)
- [x] Engine changes: the relevant `web/src/lib/warp/*.check.mjs` harness passes and covers the new behaviour (`node src/lib/warp/peer.check.mjs`)
- [x] UI checked at **~360–430px width** — no horizontal overflow, mobile branch present (`useIsMobile()`)
- [x] Design tokens + inline-style component style respected (no drive-by restyling)

### Hard constraints (see [CONTRIBUTING.md](../CONTRIBUTING.md#hard-constraints-the-soul-of-the-project))

- [x] No new recurring-cost infrastructure — no TURN, database, storage, or paid API ($0, no card, forever)
- [x] Still STUN-only — no relay in the file path; NAT failure stays an honest error
- [x] The signaling server still never reads, stores, or understands file contents
- [x] `SEND_HIGH_WATER` in `peer.ts` untouched or still well below 16 MiB
- [x] Transient network drops still recover (no new terminal errors for blips; keepalive ping intact)

## Screenshots / recordings

Manual UI check with two local tabs connected at 390px width:

- 65,537-byte text shows `Too long to send as text (66 KB). Save it as a .txt file and send that instead.`
- Send text button is disabled, textarea has `aria-invalid`, and `documentElement.scrollWidth === clientWidth === 390`
- Changing back to `short note` re-enables the button, removes the hint, and the receiver tray shows the text snippet after send

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a maximum byte-size limit for text snippets sent through sessions, enforcing the cap at the time of sending.
  - Displays a byte-size warning when the text exceeds the limit (with the formatted size), and updates the “Send text” button state accordingly.

- **Bug Fixes**
  - Prevents oversized text from being sent and ensures no corresponding transfer records are created for rejected inputs.
  - Improves accessibility by marking oversized input with `aria-invalid` and linking to the in-panel size warning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a session-killing bug where pasting a large log or base64 blob into the text composer would produce a JSON control frame exceeding the WebRTC data channel's safe single-message size. The fix caps text snippet frames at 64 KiB, enforced both at the engine layer (`WarpPeer.sendText`) and proactively in the UI.

- **`transfer.ts`** — adds `TEXT_SNIPPET_MAX_BYTES` (64 KiB) and `textSnippetFrameBytes()`, which measures the actual UTF-8 size of the serialized `{t:\"text\",…}` control frame (not just raw character count), catching JSON-escape amplification from backslash-heavy input.
- **`peer.ts`** — guards `sendText()` before the `TransferItem` is created or the channel is written, so oversized payloads produce a clean `text-too-large` error with no side effects.
- **`SessionView.tsx`** — computes the same frame-size check on every keystroke using a fixed-length probe ID, disables the send button, marks the textarea `aria-invalid`, and shows an amber hint with a suggested workaround.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the fix is narrow, well-tested, and enforcement happens at two independent layers (UI and engine).

The change is small and self-contained: a size constant plus a serialized-frame measurement helper, a pre-condition guard in sendText() that fires before any side effects, and matching UI feedback. The test harness covers normal delivery, the exact 64 KiB boundary, and two oversized-rejection paths including JSON-escape amplification. No existing wire protocol or transfer logic is touched.

**Files Needing Attention:** No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/src/lib/warp/transfer.ts | Adds TEXT_SNIPPET_MAX_BYTES constant and textSnippetFrameBytes() helper that computes the actual serialized UTF-8 frame size; reuses a module-level TextEncoder singleton to avoid allocation churn. |
| web/src/lib/warp/peer.ts | Guards sendText() by checking the serialized frame size with the real generated ID before creating the TransferItem or writing to the data channel; both the channel.send() call and the transfer event are cleanly blocked on oversized payloads. |
| web/src/transfer/SessionView.tsx | Adds pre-send validation in the Composer component using a probe ID of the same byte-length as fileId() output; shows an accessible amber hint and disables the send button when the frame would exceed 64 KiB. |
| web/src/lib/warp/peer.check.mjs | Adds three test cases: normal short text delivery, exact boundary-fitting text (frame == 64 KiB), and two oversized-rejection paths (direct oversize and backslash-heavy JSON-escape amplification); patches Math.random for deterministic frame-size boundary checks. |

<sub>Reviews (3): Last reviewed commit: ["fix(ui): reuse text snippet validation s..."](https://github.com/ishannaik/warp/commit/0ed3ee355f7b6c247c170e346aba1a34efa61621) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47413877)</sub>

<!-- /greptile_comment -->