### PR TITLE
fix(receive): rename incoming files on a directory collision

### DIFF
--- a/web/src/lib/warp/useWarpTransfer.check.mjs
+++ b/web/src/lib/warp/useWarpTransfer.check.mjs
@@ -447,6 +447,154 @@ incoming = null;
 await handleOffer(rp.remoteId, { batchId: "re6", items: [{ id: "e1", key: "busy|9|9", size: 9, resumeToken: "tok-E" }] });
 assert(incoming && incoming.batchId === "re6", "a duplicate offer for an ACTIVE file is not double-accepted");
 
+// ---- 7. Filename collisions in the directory-picker path (issue #133) --------
+//
+// The hook's uniqueName, reproduced 1:1 from useWarpTransfer.ts. It de-dupes
+// against BOTH the names used earlier in this batch and the files already on
+// disk, so an existing file keeps its name and the incoming one steps aside.
+
+async function existsInDir(dir, name) {
+  try {
+    await dir.getFileHandle(name);
+    return true;
+  } catch (err) {
+    return err?.name === "NotFoundError" ? false : "unknown";
+  }
+}
+
+async function uniqueName(used, name, dir) {
+  const dot = name.lastIndexOf(".");
+  const stem = dot > 0 ? name.slice(0, dot) : name;
+  const ext = dot > 0 ? name.slice(dot) : "";
+
+  let candidate = name;
+  for (let n = 1; ; n += 1) {
+    if (!used.has(candidate)) {
+      const onDisk = dir ? await existsInDir(dir, candidate) : false;
+      if (onDisk !== true) {
+        used.add(candidate);
+        return candidate;
+      }
+    }
+    candidate = `${stem} (${n})${ext}`;
+  }
+}
+
+/** A fake directory handle over a set of existing names. Records every probe. */
+function fakeDir(existing = [], opts = {}) {
+  const files = new Set(existing);
+  return {
+    files,
+    probes: [],
+    created: [],
+    async getFileHandle(name, options) {
+      if (options?.create) {
+        this.created.push(name);
+        files.add(name);
+        return { name };
+      }
+      this.probes.push(name);
+      if (opts.throwOnProbe) throw opts.throwOnProbe;
+      if (!files.has(name)) {
+        const e = new Error(`no such file: ${name}`);
+        e.name = "NotFoundError";
+        throw e;
+      }
+      return { name };
+    },
+  };
+}
+
+/** Resolve a whole batch the way accept() does: one shared used-set, in order. */
+async function resolveBatch(dir, names) {
+  const used = new Set();
+  const out = [];
+  for (const n of names) out.push(await uniqueName(used, n, dir));
+  return out;
+}
+
+// 7a. AC1 — a name already on disk is preserved; the incoming file steps aside.
+{
+  const dir = fakeDir(["report.pdf"]);
+  const got = await resolveBatch(dir, ["report.pdf"]);
+  assert(got[0] === "report (1).pdf", "an existing on-disk name yields 'report (1).pdf', not an overwrite");
+  assert(dir.files.has("report.pdf"), "the pre-existing file is still present (never clobbered)");
+  assert(dir.created.length === 0, "resolving a name never creates a file by itself");
+}
+
+// 7b. AC2 — three identical names in ONE batch, empty folder.
+{
+  const dir = fakeDir([]);
+  const got = await resolveBatch(dir, ["a.txt", "a.txt", "a.txt"]);
+  assert(
+    JSON.stringify(got) === JSON.stringify(["a.txt", "a (1).txt", "a (2).txt"]),
+    "three same-named files in one batch become a.txt, a (1).txt, a (2).txt",
+  );
+}
+
+// 7c. AC3 — no collision means no behaviour change.
+{
+  const dir = fakeDir(["other.txt"]);
+  const got = await resolveBatch(dir, ["fresh.txt"]);
+  assert(got[0] === "fresh.txt", "a non-colliding name is returned unchanged");
+}
+
+// 7d. On-disk AND in-batch collisions compose, continuing past both.
+{
+  const dir = fakeDir(["a.txt", "a (1).txt"]);
+  const got = await resolveBatch(dir, ["a.txt", "a.txt"]);
+  assert(
+    JSON.stringify(got) === JSON.stringify(["a (2).txt", "a (3).txt"]),
+    "disk-taken and batch-taken names are both skipped: a (2).txt then a (3).txt",
+  );
+}
+
+// 7e. The probe is CHEAP: only exact candidates, never a directory scan.
+{
+  const dir = fakeDir(["a.txt", "a (1).txt"]);
+  await resolveBatch(dir, ["a.txt"]);
+  assert(
+    JSON.stringify(dir.probes) === JSON.stringify(["a.txt", "a (1).txt", "a (2).txt"]),
+    "probes exactly the candidates it needs and stops at the first free slot",
+  );
+  assert(typeof dir.entries !== "function" && typeof dir.keys !== "function", "never enumerates the directory");
+}
+
+// 7f. An inconclusive probe (revoked permission) must NOT loop and must NOT be
+//     read as "free to overwrite something else". It yields the current
+//     candidate so the real create:true write reports the real error.
+{
+  const denied = new Error("permission denied");
+  denied.name = "NotAllowedError";
+  const dir = fakeDir(["a.txt"], { throwOnProbe: denied });
+  const got = await resolveBatch(dir, ["a.txt"]);
+  assert(got[0] === "a.txt", "an unreadable directory yields the original name and defers to the real write");
+  assert(dir.probes.length === 1, "an inconclusive probe stops probing instead of spinning for a free slot");
+}
+
+// 7g. No directory target (single-file picker / in-memory): pure in-batch
+//     behaviour, byte-identical to before, and zero probes.
+{
+  const used = new Set();
+  const a = await uniqueName(used, "a.txt", undefined);
+  const b = await uniqueName(used, "a.txt", undefined);
+  assert(a === "a.txt" && b === "a (1).txt", "with no folder target the in-batch de-dupe is unchanged");
+}
+
+// 7h. Dotfiles keep their whole name as the stem.
+{
+  const dir = fakeDir([".env"]);
+  const got = await resolveBatch(dir, [".env"]);
+  assert(got[0] === ".env (1)", "a dotfile de-dupes as '.env (1)', not ' (1).env'");
+}
+
+// 7i. Extensionless names.
+{
+  const dir = fakeDir(["README"]);
+  const got = await resolveBatch(dir, ["README"]);
+  assert(got[0] === "README (1)", "an extensionless name de-dupes as 'README (1)'");
+}
+
 if (failures) {
   console.error(`\n${failures} check(s) failed.`);
   process.exit(1);

--- a/web/src/lib/warp/useWarpTransfer.ts
+++ b/web/src/lib/warp/useWarpTransfer.ts
@@ -180,20 +180,61 @@ function labelFor(peerId: string): string {
   return peerId.slice(0, 8);
 }
 
-/** De-dupe a filename within a folder target: "a.txt", "a (1).txt", … */
-function uniqueName(used: Set<string>, name: string): string {
-  if (!used.has(name)) {
-    used.add(name);
-    return name;
+/**
+ * Does `name` already exist in `dir`?
+ *
+ * Deliberately cheap: ONE `getFileHandle` for the exact name, never a directory
+ * scan. A `NotFoundError` is the API's way of saying the slot is free.
+ *
+ * Returns "unknown" when the probe fails for any OTHER reason (a revoked
+ * permission, a transient FS error). That third state matters: treating an
+ * unreadable directory as "free" would let us overwrite a file we simply could
+ * not see, and treating it as "taken" would spin forever looking for a free slot.
+ */
+async function existsInDir(dir: FsDirHandle, name: string): Promise<boolean | "unknown"> {
+  try {
+    await dir.getFileHandle(name);
+    return true;
+  } catch (err) {
+    return (err as { name?: string } | null)?.name === "NotFoundError" ? false : "unknown";
   }
+}
+
+/**
+ * De-dupe a filename for a folder target: "a.txt", "a (1).txt", …
+ *
+ * Two different things can collide and both are checked:
+ *   - names already claimed by EARLIER FILES IN THE SAME BATCH (`used`), and
+ *   - files ALREADY ON DISK in the chosen folder (`dir`).
+ *
+ * Without the second check, receiving `report.pdf` into a folder that already
+ * holds one silently clobbered the existing file (issue #133). The existing file
+ * now always wins its name and the incoming one steps aside.
+ *
+ * When a disk probe is inconclusive we take the current candidate and stop
+ * probing, so the real `create: true` write surfaces the real error rather than
+ * this helper inventing a different filename or looping.
+ *
+ * `dir` is optional so callers with no folder target keep the pure in-batch
+ * behaviour.
+ */
+async function uniqueName(used: Set<string>, name: string, dir?: FsDirHandle): Promise<string> {
   const dot = name.lastIndexOf(".");
+  // dot > 0 keeps dotfiles whole: ".env" stems to ".env", not "" + ".env".
   const stem = dot > 0 ? name.slice(0, dot) : name;
   const ext = dot > 0 ? name.slice(dot) : "";
-  let n = 1;
-  let candidate = `${stem} (${n})${ext}`;
-  while (used.has(candidate)) candidate = `${stem} (${(n += 1)})${ext}`;
-  used.add(candidate);
-  return candidate;
+
+  let candidate = name;
+  for (let n = 1; ; n += 1) {
+    if (!used.has(candidate)) {
+      const onDisk = dir ? await existsInDir(dir, candidate) : false;
+      if (onDisk !== true) {
+        used.add(candidate);
+        return candidate;
+      }
+    }
+    candidate = `${stem} (${n})${ext}`;
+  }
 }
 
 /** Trigger a browser download of a blob via a transient object-URL anchor. */
@@ -749,8 +790,10 @@ export function useWarpTransfer(joinCode?: string): UseWarpTransfer {
       let sink: ReceiveSink;
       let savedName: string | undefined;
       if (target && "dirHandle" in target) {
-        savedName = uniqueName(usedNames, it.name);
         const dir = target.dirHandle;
+        // Probes the folder as well as this batch, so an existing file keeps its
+        // name and the incoming one becomes "name (1).ext" (issue #133).
+        savedName = await uniqueName(usedNames, it.name, dir);
         const name = savedName;
         sink = diskSink(async () => (await dir.getFileHandle(name, { create: true })).createWritable());
       } else if (target && "fileHandle" in target) {


### PR DESCRIPTION
## What & why

The directory-picker save path de-duped filenames only against the other files in the same batch, then called `getFileHandle(name, { create: true })`. A file already sitting in the chosen folder was overwritten silently, so receiving a second `report.pdf` destroyed the first.

`uniqueName` now probes the folder as well as the batch: the existing file keeps its name and the incoming one becomes `report (1).pdf`. The probe stays cheap — a single `getFileHandle` for the exact candidate, never a directory scan.

`existsInDir` reports three states rather than two. `NotFoundError` means the slot is free; any other failure is `"unknown"`, and on that we stop probing and return the current candidate so the real `create: true` write surfaces the real error. Treating an unreadable directory as free would overwrite a file we cannot see, and treating it as taken would spin forever looking for a free slot.

The `dir` argument is optional, so the single-file `showSaveFilePicker` path and the in-memory tray keep their existing behaviour.

One note on the acceptance criteria: **in-batch de-duplication already worked** before this change — three same-named files in one batch already became `a.txt`, `a (1).txt`, `a (2).txt`. Only the on-disk case was broken. That criterion now has a regression check so it stays working, but it isn't a behaviour change.

Closes #133

## Type

- [ ] feat
- [x] fix
- [ ] docs / chore / refactor / test / perf

## Checklist

- [x] `pnpm lint && pnpm typecheck` pass locally
- [x] `pnpm --filter @warp/web build` is green (web changes)
- [x] Engine changes: the relevant `web/src/lib/warp/*.check.mjs` harness passes (and covers the new behaviour)
- [x] Design tokens + inline-style component style respected (no drive-by restyling)

This is a web-only, two-file engine change, so per the template's "delete lines that genuinely don't apply" I've dropped the server-test and mobile-width rows: the diff contains no `server/` files and no UI.

### Hard constraints

- [x] No new recurring-cost infrastructure — no TURN, database, storage, or paid API
- [x] Still STUN-only — no relay in the file path
- [x] The signaling server still never reads, stores, or understands file contents
- [x] `SEND_HIGH_WATER` in `peer.ts` untouched — `peer.ts` is not in this diff at all
- [x] Transient network drops still recover — accept/resume logic untouched

## Testing

`useWarpTransfer.check.mjs` gains 13 collision cases (50 checks pass in total): the on-disk collision, three-in-one-batch, the no-collision case, combined disk + batch, probe cost, an inconclusive probe, dotfiles, and extensionless names.

Because that harness uses a fake directory handle, it proves the algorithm but not the API contract. So the behaviour was also verified against the real File System Access API through OPFS in Chrome:

- a probe for an absent name throws exactly `NotFoundError` — the assumption the whole fix rests on
- three `report.pdf` receives into a folder that already holds one leave **four** files with the original intact
- `.env` becomes `.env (1)`

As a control, the pre-fix code exercised the same way leaves **one** file with the original's contents replaced — the bug reproduced as real data loss.

## Known gaps, deliberately out of scope

- `DefaultReceiveHost` in `peer.ts` carries a second copy of the same in-memory-only de-dupe. It is not the app's path — `useWarpTransfer` injects its own `ReceiveHost` at both `new WarpPeer` sites — but a library consumer who doesn't inject one would still overwrite. Happy to fix in a follow-up if you'd like it in scope.
- Concurrent receives are not made atomic. Names resolve when the offer is accepted while handles are created lazily, so two simultaneous accepts could still pick the same free name. `getFileHandle` has no exclusive-create option, and `createWritable()` defaults to `mode: "siloed"`, so the last writer can win. `createWritable({ mode: "exclusive" })` would instead surface the clash as `NoModificationAllowedError` and could drive a retry under a fresh name, but that needs a wider `FsFileHandle` type, a change to the write path, and updated mocks, so it is a separate follow-up rather than part of this naming fix. This is pre-existing behaviour and unchanged here.
- `useWarpTransfer.check.mjs` isn't wired into `pnpm test` (`web` has no `test` script), so it has to be run explicitly, as its own header says.
- I could not drive a real `showDirectoryPicker` — it needs a user gesture and an OS dialog. OPFS exercises the same `getFileHandle` interface and is the closest substitute, which is why the control above matters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented directory-based transfers from overwriting existing files.
  * Improved filename handling for duplicate files, including dotfiles and extensionless names.
  * Added safeguards for collisions between files transferred in the same batch.
  * Improved error handling when the destination cannot be checked reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a silent data-loss bug (#133) where receiving a file into a folder that already contained a same-named file would overwrite it. `uniqueName` is promoted to async and extended to probe the chosen directory with a single cheap `getFileHandle` call per candidate, so the existing file keeps its name and the incoming file steps aside.

- `existsInDir` introduces a three-state return (`true` / `false` / `\"unknown\"`) so an unreadable directory neither causes infinite looping nor silently overwrites an invisible file — an inconclusive probe returns the current candidate immediately, deferring the real error to the subsequent `create: true` write.
- The `accept` callback in `useWarpTransfer.ts` was already async, so the addition of `await uniqueName(…, dir)` fits naturally into the existing flow.
- Nine new scenarios in `useWarpTransfer.check.mjs` cover on-disk collision, pure in-batch deduplication, combined disk+batch, the \"unknown\" probe path, probe cost, dotfiles, and extensionless names.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge — the overwrite bug is correctly fixed, all edge cases are covered, and the async change fits naturally into an already-async accept callback.

The algorithm is correct and well-documented. The only concern is that the test helpers in the .check.mjs file are manually duplicated from the production TypeScript, meaning a future algorithm change won't automatically be reflected in the tests unless the test file is also updated.

**Files Needing Attention:** web/src/lib/warp/useWarpTransfer.check.mjs — the hand-copied existsInDir and uniqueName helpers need to stay in sync with their counterparts in useWarpTransfer.ts.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/src/lib/warp/useWarpTransfer.ts | Refactors uniqueName from sync to async, adds existsInDir helper, and threads dir probe into accept()'s folder-target path. Logic is correct: unknown probe state defers to the real write, used-set tracks in-batch deduplication, and the dotfile/extensionless edge cases are handled. |
| web/src/lib/warp/useWarpTransfer.check.mjs | Adds 9 well-structured test scenarios covering on-disk collision, in-batch deduplication, combined disk+batch, the unknown probe path, dotfiles, and extensionless names. The existsInDir and uniqueName helpers are hand-copied from the .ts source rather than imported, which creates a drift risk if the production algorithm is updated without also updating the test file. |

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aweb%2Fsrc%2Flib%2Fwarp%2FuseWarpTransfer.check.mjs%3A461-493%0A**Test%20helpers%20hand-copied%20from%20production%20source**%0A%0A%60existsInDir%60%20and%20%60uniqueName%60%20in%20this%20file%20are%20manually%20duplicated%20from%20%60useWarpTransfer.ts%60%20%28the%20comment%20even%20calls%20this%20out%3A%20%22reproduced%201%3A1%22%29.%20Because%20the%20test%20is%20run%20with%20bare%20%60node%60%20and%20can't%20import%20TypeScript%2C%20that%20constraint%20is%20real%20%E2%80%94%20but%20it%20means%20any%20future%20change%20to%20the%20production%20algorithm%20that%20isn't%20mirrored%20here%20will%20pass%20all%209%20collision%20checks%20while%20silently%20testing%20the%20old%20logic.%20The%20%221%3A1%22%20comment%20depends%20on%20a%20human%20catching%20the%20drift%2C%20not%20tooling.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ishannaik%2Fwarp&pr=168&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ishannaik%2Fwarp%22%20on%20the%20existing%20branch%20%22fix%2Freceive-filename-collision%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Freceive-filename-collision%22.%0A%0A%23%23%23%20Issue%201%0Aweb%2Fsrc%2Flib%2Fwarp%2FuseWarpTransfer.check.mjs%3A461-493%0A**Test%20helpers%20hand-copied%20from%20production%20source**%0A%0A%60existsInDir%60%20and%20%60uniqueName%60%20in%20this%20file%20are%20manually%20duplicated%20from%20%60useWarpTransfer.ts%60%20%28the%20comment%20even%20calls%20this%20out%3A%20%22reproduced%201%3A1%22%29.%20Because%20the%20test%20is%20run%20with%20bare%20%60node%60%20and%20can't%20import%20TypeScript%2C%20that%20constraint%20is%20real%20%E2%80%94%20but%20it%20means%20any%20future%20change%20to%20the%20production%20algorithm%20that%20isn't%20mirrored%20here%20will%20pass%20all%209%20collision%20checks%20while%20silently%20testing%20the%20old%20logic.%20The%20%221%3A1%22%20comment%20depends%20on%20a%20human%20catching%20the%20drift%2C%20not%20tooling.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ishannaik%2Fwarp&pr=168&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Aweb%2Fsrc%2Flib%2Fwarp%2FuseWarpTransfer.check.mjs%3A461-493%0A**Test%20helpers%20hand-copied%20from%20production%20source**%0A%0A%60existsInDir%60%20and%20%60uniqueName%60%20in%20this%20file%20are%20manually%20duplicated%20from%20%60useWarpTransfer.ts%60%20%28the%20comment%20even%20calls%20this%20out%3A%20%22reproduced%201%3A1%22%29.%20Because%20the%20test%20is%20run%20with%20bare%20%60node%60%20and%20can't%20import%20TypeScript%2C%20that%20constraint%20is%20real%20%E2%80%94%20but%20it%20means%20any%20future%20change%20to%20the%20production%20algorithm%20that%20isn't%20mirrored%20here%20will%20pass%20all%209%20collision%20checks%20while%20silently%20testing%20the%20old%20logic.%20The%20%221%3A1%22%20comment%20depends%20on%20a%20human%20catching%20the%20drift%2C%20not%20tooling.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=168&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/lib/warp/useWarpTransfer.check.mjs:461-493
**Test helpers hand-copied from production source**

`existsInDir` and `uniqueName` in this file are manually duplicated from `useWarpTransfer.ts` (the comment even calls this out: "reproduced 1:1"). Because the test is run with bare `node` and can't import TypeScript, that constraint is real — but it means any future change to the production algorithm that isn't mirrored here will pass all 9 collision checks while silently testing the old logic. The "1:1" comment depends on a human catching the drift, not tooling.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(receive): rename incoming files on a..."](https://github.com/ishannaik/warp/commit/ee1a6e680b155f12a47543a6dffd2889e15e850e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49300637)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->