### PR TITLE
docs(peer): move thumbnail JSDoc to constant

### DIFF
--- a/web/src/lib/warp/peer.ts
+++ b/web/src/lib/warp/peer.ts
@@ -1110,7 +1110,6 @@ export class WarpPeer {
   }
 }
 
-/** Max edge of a generated thumbnail, in CSS pixels. */
 /**
  * Validate a receiver-supplied resume offset (Fable L1): must be a non-negative
  * integer no larger than the file. Anything else (NaN, negative, >size, non-int —
@@ -1121,6 +1120,7 @@ function clampOffset(v: unknown, size: number): number {
   return typeof v === "number" && Number.isInteger(v) && v >= 0 && v <= size ? v : 0;
 }
 
+/** Max edge of a generated thumbnail, in CSS pixels. */
 const THUMB_MAX = 64;
 
 /**


### PR DESCRIPTION
## What & why

Moves the thumbnail-size JSDoc from `clampOffset` to `THUMB_MAX` so generated docs and hover text describe the correct symbol. No logic changes.

Closes #177

## Type

- [ ] feat
- [ ] fix
- [x] docs / chore / refactor / test / perf

## Checklist

- [x] `pnpm lint && pnpm typecheck` pass locally
- [x] `pnpm --filter @warp/web build` is green (web changes)
- [ ] `pnpm --filter @warp/server test` passes (server changes)
- [x] Engine changes: the relevant `web/src/lib/warp/*.check.mjs` harness passes (and covers the new behaviour)
- [ ] UI checked at **~360–430px width** — no horizontal overflow, mobile branch present (`useIsMobile()`)
- [x] Design tokens + inline-style component style respected (no drive-by restyling)

Server and UI checks are not applicable: this is a comment-only engine docs change with no rendered UI or server code.

### Hard constraints

- [x] No new recurring-cost infrastructure — no TURN, database, storage, or paid API ($0, no card, forever)
- [x] Still STUN-only — no relay in the file path; NAT failure stays an honest error
- [x] The signaling server still never reads, stores, or understands file contents
- [x] `SEND_HIGH_WATER` in `peer.ts` untouched or still well below 16 MiB
- [x] Transient network drops still recover (no new terminal errors for blips; keepalive ping intact)

## Validation

- `node src/lib/warp/peer.check.mjs`
- `pnpm lint` (passes with existing warnings)
- `pnpm typecheck`
- `pnpm --filter @warp/web build`
- `git diff --check`

## Screenshots / recordings

Not applicable: no UI change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the placement of thumbnail size documentation for improved code readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Moves the `/** Max edge of a generated thumbnail, in CSS pixels. */` JSDoc from an erroneous position preceding `clampOffset`'s own block comment to immediately above `THUMB_MAX = 64`, where it correctly documents that constant.

- The misplaced comment was sandwiched between two unrelated JSDoc blocks, causing IDE hover text and generated docs to describe the wrong symbol; placing it directly above `THUMB_MAX` corrects this.
- No logic, runtime behaviour, or type signatures are affected — this is a comment-only reposition.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — comment-only reposition with no runtime impact.

The change is purely cosmetic: one JSDoc line removed from an incorrect position and added immediately above the constant it describes. No logic, types, or exports are touched, and the harness/lint/typecheck are confirmed green.

**Files Needing Attention:** No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/src/lib/warp/peer.ts | JSDoc for THUMB_MAX moved from above clampOffset to directly above the constant; no logic changes. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph Before["Before (incorrect placement)"]
        A["/** Max edge of a generated thumbnail… */"]
        B["/** Validate a receiver-supplied resume offset… */\nfunction clampOffset()"]
        C["const THUMB_MAX = 64"]
        A --> B --> C
    end

    subgraph After["After (correct placement)"]
        D["/** Validate a receiver-supplied resume offset… */\nfunction clampOffset()"]
        E["/** Max edge of a generated thumbnail… */\nconst THUMB_MAX = 64"]
        D --> E
    end

    Before -.->|"JSDoc moved to correct symbol"| After
```
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(peer): move thumbnail JSDoc to cons..."](https://github.com/ishannaik/warp/commit/6f154c079ac209e669b3636661e3b81d3feb7743) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49950305)</sub>

<!-- /greptile_comment -->