### PR TITLE
a11y(faq): aria-controls + drop ambiguous 'our relay' wording

### DIFF
--- a/web/src/sections/Faq.tsx
+++ b/web/src/sections/Faq.tsx
@@ -3,7 +3,7 @@ import { useIsMobile } from "../lib/useIsMobile";
 
 /**
  * Section 05 — "Questions".
- * Accordion of the five honest answers, ported verbatim from the Wrap
+ * Accordion of the five honest answers, ported verbatim from the Warp
  * design source (#faq).
  *
  * The source used a vanilla-JS max-height toggle; here a single open index is
@@ -85,7 +85,7 @@ interface Item {
 const ITEMS: Item[] = [
   {
     q: "Is it really peer-to-peer?",
-    a: "Yes. Once two devices pair, the file travels directly between them over an encrypted WebRTC channel. Our relay only helps them find each other — it never sees the contents.",
+    a: "Yes. Once two devices pair, the file travels directly between them over an encrypted WebRTC channel. A small signaling server only helps them find each other — it never sees the contents.",
   },
   {
     q: "What’s the maximum file size?",
@@ -137,6 +137,7 @@ export default function Faq() {
                 <button
                   type="button"
                   aria-expanded={open}
+                  aria-controls={`faq-panel-${i}`}
                   style={{
                     ...triggerStyle,
                     gap: isMobile ? "12px" : triggerStyle.gap,
@@ -164,6 +165,7 @@ export default function Faq() {
                   </span>
                 </button>
                 <div
+                  id={`faq-panel-${i}`}
                   style={{
                     display: "grid",
                     gridTemplateRows: open ? "1fr" : "0fr",


### PR DESCRIPTION
## Summary
- Wire each FAQ accordion button to its answer panel with `aria-controls` / matching `id` (closes #185)
- Replace "Our relay" with "A small signaling server" so it does not clash with the no-TURN FAQ (closes #180)
- Header comment Wrap → Warp while touching the file

## Test plan
- [ ] Expand/collapse FAQ items with keyboard and pointer
- [ ] Confirm `aria-controls` on each trigger matches `faq-panel-N`
- [ ] First FAQ answer no longer says "Our relay"
- [ ] Spot-check ~360px accordion layout


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated FAQ content to accurately describe peer-to-peer connections using a signaling server.
  * Improved accessibility by linking each FAQ question to its corresponding answer panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR improves accessibility in the FAQ accordion by wiring each trigger button to its answer panel via `aria-controls` / matching `id`, and fixes a content inconsistency by replacing "Our relay" with "A small signaling server" to align with the no-TURN policy stated elsewhere in the same FAQ. A header comment typo ("Wrap" → "Warp") is also corrected.

- **`aria-controls` + `id` pairing** (lines 140, 168): each button now references its panel by a stable index-based id (`faq-panel-N`), giving screen-reader users an explicit control-to-panel link.
- **Text correction** (line 88): "A small signaling server" avoids contradicting the fourth FAQ item that explicitly states there is no relay fallback.
- **Remaining a11y gap**: collapsed panels are hidden only visually (CSS grid animation) — the content is still reachable in the accessibility tree; adding the `hidden` attribute when closed and `role="region"` + `aria-labelledby` on the panel would complete the WAI-ARIA accordion pattern.
</details>


<h3>Confidence Score: 4/5</h3>

Safe to merge; changes are additive ARIA attributes and a copy fix with no risk to transfer logic or layout.

The aria-controls/id wiring is correctly implemented and the copy change resolves a real contradiction in the FAQ. Two follow-up gaps exist: collapsed panels are still reachable in the accessibility tree, and the WAI-ARIA accordion pattern is only half-complete without role=region and aria-labelledby on the panels. Neither breaks anything today, but they limit the a11y benefit of this PR.

**Files Needing Attention:** web/src/sections/Faq.tsx — the panel collapse behaviour and missing region role are worth addressing in a follow-up.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/src/sections/Faq.tsx | Adds aria-controls/id wiring for accordion buttons+panels and replaces ambiguous 'Our relay' with 'A small signaling server'; two a11y refinements (panel AT-hiding, role=region) would complete the WAI-ARIA pattern |


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User as User
    participant Button as Accordion Button
    participant State as React State
    participant Panel as Answer Panel
    participant AT as Assistive Technology

    User->>Button: click / Enter / Space
    Button->>State: setOpenIndex(i or null)
    State->>Button: aria-expanded true or false
    State->>Panel: gridTemplateRows 1fr or 0fr
    AT->>Button: reads aria-expanded and aria-controls
    AT->>Panel: follows aria-controls to faq-panel-N
    Note over Panel,AT: Content stays in AT tree when collapsed - no hidden attr
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `web/src/sections/Faq.tsx`, line 167-174 ([link](https://github.com/ishannaik/warp/blob/704cead98dfd98fbfeb07f728f4c7ab4d534bef4/web/src/sections/Faq.tsx#L167-L174)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Collapsed panels remain in the accessibility tree**

   The grid-template-rows `0fr` animation keeps content in the DOM without hiding it from assistive technologies — `overflow: hidden` and zero height do not remove elements from the accessibility tree. With `aria-controls` now explicitly wiring the button to the panel, a screen reader that follows the reference will land on the panel and still read its text even when `aria-expanded="false"`. Adding the `hidden` attribute when closed (and removing it when open) would suppress the content from AT while React continues to own the animation transition, matching the WAI-ARIA accordion authoring pattern.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: web/src/sections/Faq.tsx
   Line: 167-174

   Comment:
   **Collapsed panels remain in the accessibility tree**

   The grid-template-rows `0fr` animation keeps content in the DOM without hiding it from assistive technologies — `overflow: hidden` and zero height do not remove elements from the accessibility tree. With `aria-controls` now explicitly wiring the button to the panel, a screen reader that follows the reference will land on the panel and still read its text even when `aria-expanded="false"`. Adding the `hidden` attribute when closed (and removing it when open) would suppress the content from AT while React continues to own the animation transition, matching the WAI-ARIA accordion authoring pattern.

   ---

   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20web%2Fsrc%2Fsections%2FFaq.tsx%0ALine%3A%20167-174%0A%0AComment%3A%0A**Collapsed%20panels%20remain%20in%20the%20accessibility%20tree**%0A%0AThe%20grid-template-rows%20%600fr%60%20animation%20keeps%20content%20in%20the%20DOM%20without%20hiding%20it%20from%20assistive%20technologies%20%E2%80%94%20%60overflow%3A%20hidden%60%20and%20zero%20height%20do%20not%20remove%20elements%20from%20the%20accessibility%20tree.%20With%20%60aria-controls%60%20now%20explicitly%20wiring%20the%20button%20to%20the%20panel%2C%20a%20screen%20reader%20that%20follows%20the%20reference%20will%20land%20on%20the%20panel%20and%20still%20read%20its%20text%20even%20when%20%60aria-expanded%3D%22false%22%60.%20Adding%20the%20%60hidden%60%20attribute%20when%20closed%20%28and%20removing%20it%20when%20open%29%20would%20suppress%20the%20content%20from%20AT%20while%20React%20continues%20to%20own%20the%20animation%20transition%2C%20matching%20the%20WAI-ARIA%20accordion%20authoring%20pattern.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ishannaik%2Fwarp&pr=191&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ishannaik%2Fwarp%22%20on%20the%20existing%20branch%20%22fix%2Ffaq-a11y-180-185%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Ffaq-a11y-180-185%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20web%2Fsrc%2Fsections%2FFaq.tsx%0ALine%3A%20167-174%0A%0AComment%3A%0A**Collapsed%20panels%20remain%20in%20the%20accessibility%20tree**%0A%0AThe%20grid-template-rows%20%600fr%60%20animation%20keeps%20content%20in%20the%20DOM%20without%20hiding%20it%20from%20assistive%20technologies%20%E2%80%94%20%60overflow%3A%20hidden%60%20and%20zero%20height%20do%20not%20remove%20elements%20from%20the%20accessibility%20tree.%20With%20%60aria-controls%60%20now%20explicitly%20wiring%20the%20button%20to%20the%20panel%2C%20a%20screen%20reader%20that%20follows%20the%20reference%20will%20land%20on%20the%20panel%20and%20still%20read%20its%20text%20even%20when%20%60aria-expanded%3D%22false%22%60.%20Adding%20the%20%60hidden%60%20attribute%20when%20closed%20%28and%20removing%20it%20when%20open%29%20would%20suppress%20the%20content%20from%20AT%20while%20React%20continues%20to%20own%20the%20animation%20transition%2C%20matching%20the%20WAI-ARIA%20accordion%20authoring%20pattern.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ishannaik%2Fwarp&pr=191&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20web%2Fsrc%2Fsections%2FFaq.tsx%0ALine%3A%20167-174%0A%0AComment%3A%0A**Collapsed%20panels%20remain%20in%20the%20accessibility%20tree**%0A%0AThe%20grid-template-rows%20%600fr%60%20animation%20keeps%20content%20in%20the%20DOM%20without%20hiding%20it%20from%20assistive%20technologies%20%E2%80%94%20%60overflow%3A%20hidden%60%20and%20zero%20height%20do%20not%20remove%20elements%20from%20the%20accessibility%20tree.%20With%20%60aria-controls%60%20now%20explicitly%20wiring%20the%20button%20to%20the%20panel%2C%20a%20screen%20reader%20that%20follows%20the%20reference%20will%20land%20on%20the%20panel%20and%20still%20read%20its%20text%20even%20when%20%60aria-expanded%3D%22false%22%60.%20Adding%20the%20%60hidden%60%20attribute%20when%20closed%20%28and%20removing%20it%20when%20open%29%20would%20suppress%20the%20content%20from%20AT%20while%20React%20continues%20to%20own%20the%20animation%20transition%2C%20matching%20the%20WAI-ARIA%20accordion%20authoring%20pattern.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=191&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a>


2. `web/src/sections/Faq.tsx`, line 137-146 ([link](https://github.com/ishannaik/warp/blob/704cead98dfd98fbfeb07f728f4c7ab4d534bef4/web/src/sections/Faq.tsx#L137-L146)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **WAI-ARIA accordion pattern incomplete**

   The button gains `aria-controls` but has no `id`, so the reciprocal `aria-labelledby` link from panel back to button cannot be made. The WAI-ARIA Accordion authoring pattern calls for each button to carry an `id` and each panel to carry `role="region"` + `aria-labelledby` matching that `id`. Adding both gives screen reader users the panel-to-question context when they navigate directly to the panel region.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: web/src/sections/Faq.tsx
   Line: 137-146

   Comment:
   **WAI-ARIA accordion pattern incomplete**

   The button gains `aria-controls` but has no `id`, so the reciprocal `aria-labelledby` link from panel back to button cannot be made. The WAI-ARIA Accordion authoring pattern calls for each button to carry an `id` and each panel to carry `role="region"` + `aria-labelledby` matching that `id`. Adding both gives screen reader users the panel-to-question context when they navigate directly to the panel region.

   ---

   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20web%2Fsrc%2Fsections%2FFaq.tsx%0ALine%3A%20137-146%0A%0AComment%3A%0A**WAI-ARIA%20accordion%20pattern%20incomplete**%0A%0AThe%20button%20gains%20%60aria-controls%60%20but%20has%20no%20%60id%60%2C%20so%20the%20reciprocal%20%60aria-labelledby%60%20link%20from%20panel%20back%20to%20button%20cannot%20be%20made.%20The%20WAI-ARIA%20Accordion%20authoring%20pattern%20calls%20for%20each%20button%20to%20carry%20an%20%60id%60%20and%20each%20panel%20to%20carry%20%60role%3D%22region%22%60%20%2B%20%60aria-labelledby%60%20matching%20that%20%60id%60.%20Adding%20both%20gives%20screen%20reader%20users%20the%20panel-to-question%20context%20when%20they%20navigate%20directly%20to%20the%20panel%20region.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ishannaik%2Fwarp&pr=191&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ishannaik%2Fwarp%22%20on%20the%20existing%20branch%20%22fix%2Ffaq-a11y-180-185%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Ffaq-a11y-180-185%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20web%2Fsrc%2Fsections%2FFaq.tsx%0ALine%3A%20137-146%0A%0AComment%3A%0A**WAI-ARIA%20accordion%20pattern%20incomplete**%0A%0AThe%20button%20gains%20%60aria-controls%60%20but%20has%20no%20%60id%60%2C%20so%20the%20reciprocal%20%60aria-labelledby%60%20link%20from%20panel%20back%20to%20button%20cannot%20be%20made.%20The%20WAI-ARIA%20Accordion%20authoring%20pattern%20calls%20for%20each%20button%20to%20carry%20an%20%60id%60%20and%20each%20panel%20to%20carry%20%60role%3D%22region%22%60%20%2B%20%60aria-labelledby%60%20matching%20that%20%60id%60.%20Adding%20both%20gives%20screen%20reader%20users%20the%20panel-to-question%20context%20when%20they%20navigate%20directly%20to%20the%20panel%20region.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ishannaik%2Fwarp&pr=191&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20web%2Fsrc%2Fsections%2FFaq.tsx%0ALine%3A%20137-146%0A%0AComment%3A%0A**WAI-ARIA%20accordion%20pattern%20incomplete**%0A%0AThe%20button%20gains%20%60aria-controls%60%20but%20has%20no%20%60id%60%2C%20so%20the%20reciprocal%20%60aria-labelledby%60%20link%20from%20panel%20back%20to%20button%20cannot%20be%20made.%20The%20WAI-ARIA%20Accordion%20authoring%20pattern%20calls%20for%20each%20button%20to%20carry%20an%20%60id%60%20and%20each%20panel%20to%20carry%20%60role%3D%22region%22%60%20%2B%20%60aria-labelledby%60%20matching%20that%20%60id%60.%20Adding%20both%20gives%20screen%20reader%20users%20the%20panel-to-question%20context%20when%20they%20navigate%20directly%20to%20the%20panel%20region.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=191&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aweb%2Fsrc%2Fsections%2FFaq.tsx%3A167-174%0A**Collapsed%20panels%20remain%20in%20the%20accessibility%20tree**%0A%0AThe%20grid-template-rows%20%600fr%60%20animation%20keeps%20content%20in%20the%20DOM%20without%20hiding%20it%20from%20assistive%20technologies%20%E2%80%94%20%60overflow%3A%20hidden%60%20and%20zero%20height%20do%20not%20remove%20elements%20from%20the%20accessibility%20tree.%20With%20%60aria-controls%60%20now%20explicitly%20wiring%20the%20button%20to%20the%20panel%2C%20a%20screen%20reader%20that%20follows%20the%20reference%20will%20land%20on%20the%20panel%20and%20still%20read%20its%20text%20even%20when%20%60aria-expanded%3D%22false%22%60.%20Adding%20the%20%60hidden%60%20attribute%20when%20closed%20%28and%20removing%20it%20when%20open%29%20would%20suppress%20the%20content%20from%20AT%20while%20React%20continues%20to%20own%20the%20animation%20transition%2C%20matching%20the%20WAI-ARIA%20accordion%20authoring%20pattern.%0A%0A%23%23%23%20Issue%202%0Aweb%2Fsrc%2Fsections%2FFaq.tsx%3A137-146%0A**WAI-ARIA%20accordion%20pattern%20incomplete**%0A%0AThe%20button%20gains%20%60aria-controls%60%20but%20has%20no%20%60id%60%2C%20so%20the%20reciprocal%20%60aria-labelledby%60%20link%20from%20panel%20back%20to%20button%20cannot%20be%20made.%20The%20WAI-ARIA%20Accordion%20authoring%20pattern%20calls%20for%20each%20button%20to%20carry%20an%20%60id%60%20and%20each%20panel%20to%20carry%20%60role%3D%22region%22%60%20%2B%20%60aria-labelledby%60%20matching%20that%20%60id%60.%20Adding%20both%20gives%20screen%20reader%20users%20the%20panel-to-question%20context%20when%20they%20navigate%20directly%20to%20the%20panel%20region.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ishannaik%2Fwarp&pr=191&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ishannaik%2Fwarp%22%20on%20the%20existing%20branch%20%22fix%2Ffaq-a11y-180-185%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Ffaq-a11y-180-185%22.%0A%0A%23%23%23%20Issue%201%0Aweb%2Fsrc%2Fsections%2FFaq.tsx%3A167-174%0A**Collapsed%20panels%20remain%20in%20the%20accessibility%20tree**%0A%0AThe%20grid-template-rows%20%600fr%60%20animation%20keeps%20content%20in%20the%20DOM%20without%20hiding%20it%20from%20assistive%20technologies%20%E2%80%94%20%60overflow%3A%20hidden%60%20and%20zero%20height%20do%20not%20remove%20elements%20from%20the%20accessibility%20tree.%20With%20%60aria-controls%60%20now%20explicitly%20wiring%20the%20button%20to%20the%20panel%2C%20a%20screen%20reader%20that%20follows%20the%20reference%20will%20land%20on%20the%20panel%20and%20still%20read%20its%20text%20even%20when%20%60aria-expanded%3D%22false%22%60.%20Adding%20the%20%60hidden%60%20attribute%20when%20closed%20%28and%20removing%20it%20when%20open%29%20would%20suppress%20the%20content%20from%20AT%20while%20React%20continues%20to%20own%20the%20animation%20transition%2C%20matching%20the%20WAI-ARIA%20accordion%20authoring%20pattern.%0A%0A%23%23%23%20Issue%202%0Aweb%2Fsrc%2Fsections%2FFaq.tsx%3A137-146%0A**WAI-ARIA%20accordion%20pattern%20incomplete**%0A%0AThe%20button%20gains%20%60aria-controls%60%20but%20has%20no%20%60id%60%2C%20so%20the%20reciprocal%20%60aria-labelledby%60%20link%20from%20panel%20back%20to%20button%20cannot%20be%20made.%20The%20WAI-ARIA%20Accordion%20authoring%20pattern%20calls%20for%20each%20button%20to%20carry%20an%20%60id%60%20and%20each%20panel%20to%20carry%20%60role%3D%22region%22%60%20%2B%20%60aria-labelledby%60%20matching%20that%20%60id%60.%20Adding%20both%20gives%20screen%20reader%20users%20the%20panel-to-question%20context%20when%20they%20navigate%20directly%20to%20the%20panel%20region.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ishannaik%2Fwarp&pr=191&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Aweb%2Fsrc%2Fsections%2FFaq.tsx%3A167-174%0A**Collapsed%20panels%20remain%20in%20the%20accessibility%20tree**%0A%0AThe%20grid-template-rows%20%600fr%60%20animation%20keeps%20content%20in%20the%20DOM%20without%20hiding%20it%20from%20assistive%20technologies%20%E2%80%94%20%60overflow%3A%20hidden%60%20and%20zero%20height%20do%20not%20remove%20elements%20from%20the%20accessibility%20tree.%20With%20%60aria-controls%60%20now%20explicitly%20wiring%20the%20button%20to%20the%20panel%2C%20a%20screen%20reader%20that%20follows%20the%20reference%20will%20land%20on%20the%20panel%20and%20still%20read%20its%20text%20even%20when%20%60aria-expanded%3D%22false%22%60.%20Adding%20the%20%60hidden%60%20attribute%20when%20closed%20%28and%20removing%20it%20when%20open%29%20would%20suppress%20the%20content%20from%20AT%20while%20React%20continues%20to%20own%20the%20animation%20transition%2C%20matching%20the%20WAI-ARIA%20accordion%20authoring%20pattern.%0A%0A%23%23%23%20Issue%202%0Aweb%2Fsrc%2Fsections%2FFaq.tsx%3A137-146%0A**WAI-ARIA%20accordion%20pattern%20incomplete**%0A%0AThe%20button%20gains%20%60aria-controls%60%20but%20has%20no%20%60id%60%2C%20so%20the%20reciprocal%20%60aria-labelledby%60%20link%20from%20panel%20back%20to%20button%20cannot%20be%20made.%20The%20WAI-ARIA%20Accordion%20authoring%20pattern%20calls%20for%20each%20button%20to%20carry%20an%20%60id%60%20and%20each%20panel%20to%20carry%20%60role%3D%22region%22%60%20%2B%20%60aria-labelledby%60%20matching%20that%20%60id%60.%20Adding%20both%20gives%20screen%20reader%20users%20the%20panel-to-question%20context%20when%20they%20navigate%20directly%20to%20the%20panel%20region.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=191&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/sections/Faq.tsx:167-174
**Collapsed panels remain in the accessibility tree**

The grid-template-rows `0fr` animation keeps content in the DOM without hiding it from assistive technologies — `overflow: hidden` and zero height do not remove elements from the accessibility tree. With `aria-controls` now explicitly wiring the button to the panel, a screen reader that follows the reference will land on the panel and still read its text even when `aria-expanded="false"`. Adding the `hidden` attribute when closed (and removing it when open) would suppress the content from AT while React continues to own the animation transition, matching the WAI-ARIA accordion authoring pattern.

### Issue 2
web/src/sections/Faq.tsx:137-146
**WAI-ARIA accordion pattern incomplete**

The button gains `aria-controls` but has no `id`, so the reciprocal `aria-labelledby` link from panel back to button cannot be made. The WAI-ARIA Accordion authoring pattern calls for each button to carry an `id` and each panel to carry `role="region"` + `aria-labelledby` matching that `id`. Adding both gives screen reader users the panel-to-question context when they navigate directly to the panel region.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["a11y(faq): aria-controls on accordion + ..."](https://github.com/ishannaik/warp/commit/704cead98dfd98fbfeb07f728f4c7ab4d534bef4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49952437)</sub>

<!-- /greptile_comment -->