### PR TITLE
a11y(stats): respect prefers-reduced-motion on count-up

### DIFF
--- a/web/src/sections/Stats.tsx
+++ b/web/src/sections/Stats.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { useIsMobile } from "../lib/useIsMobile";
+import { useReducedMotion } from "../lib/useReducedMotion";
 
 /**
  * Stats — the "03 / speed" stats band.
@@ -10,12 +11,21 @@ import { useIsMobile } from "../lib/useIsMobile";
 const COUNT_DURATION = 1500; // ms
 const easeOutCubic = (k: number) => 1 - Math.pow(1 - k, 3);
 
-/** Count up from 0 to `target` once `start` flips true. */
-function useCountUp(target: number, decimals: number, start: boolean) {
+/** Count up from 0 to `target` once `start` flips true. Snaps when reduced. */
+function useCountUp(
+  target: number,
+  decimals: number,
+  start: boolean,
+  reducedMotion: boolean,
+) {
   const [value, setValue] = useState(0);
 
   useEffect(() => {
     if (!start) return;
+    if (reducedMotion) {
+      setValue(target);
+      return;
+    }
     let raf = 0;
     let t0 = 0;
     const tick = (now: number) => {
@@ -26,7 +36,7 @@ function useCountUp(target: number, decimals: number, start: boolean) {
     };
     raf = requestAnimationFrame(tick);
     return () => cancelAnimationFrame(raf);
-  }, [target, start]);
+  }, [target, start, reducedMotion]);
 
   return value.toFixed(decimals);
 }
@@ -75,10 +85,11 @@ const label: React.CSSProperties = {
 export default function Stats() {
   const { ref, inView } = useInView<HTMLDivElement>();
   const isMobile = useIsMobile();
+  const reducedMotion = useReducedMotion();
 
-  const servers = useCountUp(0, 0, inView); // 0 — stays 0
-  const bits = useCountUp(256, 0, inView); // 256
-  const peak = useCountUp(2.4, 1, inView); // 2.4 GB/s
+  const servers = useCountUp(0, 0, inView, reducedMotion); // 0 — stays 0
+  const bits = useCountUp(256, 0, inView, reducedMotion); // 256
+  const peak = useCountUp(2.4, 1, inView, reducedMotion); // 2.4 GB/s
 
   // On mobile, reduce cell padding so big numbers + labels fit without overflow.
   const mobileCell: React.CSSProperties = isMobile


### PR DESCRIPTION
## Summary
- Stats count-up reuses `useReducedMotion` and snaps to final values when reduced motion is preferred (closes #184)
- Default motion path still rAF tween on scroll-into-view

## Test plan
- [ ] Enable prefers-reduced-motion:reduce — numbers appear at final values with no tween
- [ ] Default motion still counts up on #speed enter
- [ ] Layout OK at ~360-430px

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR wires `useReducedMotion` into the Stats section's count-up hook so that users with `prefers-reduced-motion: reduce` see final values instantly instead of watching the tween animation. The existing shared hook is reused correctly and the effect dependency array is updated to include `reducedMotion`.

- `useCountUp` gains a `reducedMotion` boolean that, when true, skips the rAF loop and immediately calls `setValue(target)`. The existing cleanup path (`cancelAnimationFrame`) still fires correctly when `reducedMotion` flips while an animation is mid-flight.
- `Stats` calls `useReducedMotion()` once and threads the result into each of the three `useCountUp` calls.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge; the only issue is a one-frame visual flash that only appears if a user disables reduced motion in their OS while the stats section is already scrolled into view.

The animation snap logic is correct, the effect cleanup cancels in-flight rAF loops as expected, and the shared useReducedMotion hook is reused cleanly. The one edge case — a momentary flash from the final value to 0 when reducedMotion transitions true→false while start is already true — is cosmetic and requires an unlikely sequence of events to surface.

**Files Needing Attention:** web/src/sections/Stats.tsx — specifically the useCountUp effect where the animation restarts without first resetting state to 0

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/src/sections/Stats.tsx | Adds reducedMotion parameter to useCountUp and threads useReducedMotion() through Stats; one edge-case flash when reduced motion is disabled mid-animation |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Stats mounts] --> B[useReducedMotion]
    B --> C{prefers-reduced-motion?}
    C -->|yes| D[reducedMotion = true]
    C -->|no| E[reducedMotion = false]
    D --> F[useCountUp called]
    E --> F
    F --> G{inView / start?}
    G -->|no| H[value stays 0]
    G -->|yes| I{reducedMotion?}
    I -->|yes| J[setValue target — instant snap]
    I -->|no| K[rAF tween 0 → target over 1500 ms]
    K --> L{k < 1?}
    L -->|yes| K
    L -->|no| M[animation complete]
    J --> N[render final value]
    M --> N
    N --> O{reducedMotion changes?}
    O -->|true→false| P[cancelAnimationFrame no-op, restart tween from 0]
    O -->|false→true| Q[cancelAnimationFrame raf, setValue target]
    P --> N
    Q --> N
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aweb%2Fsrc%2Fsections%2FStats.tsx%3A25-29%0AWhen%20%60reducedMotion%60%20flips%20from%20%60true%60%20%E2%86%92%20%60false%60%20while%20the%20section%20is%20already%20in%20view%2C%20the%20state%20%60value%60%20is%20already%20at%20%60target%60%20%28from%20the%20snap%29.%20The%20first%20%60tick%60%20call%20immediately%20writes%20%60setValue%28target%20*%20easeOutCubic%280%29%29%20%3D%3D%3D%20setValue%280%29%60%2C%20causing%20a%20one-frame%20flash%20of%20the%20final%20value%20%E2%86%92%200%20%E2%86%92%20counting%20back%20up.%20Resetting%20state%20to%200%20before%20starting%20the%20animation%20prevents%20this.%0A%0A%60%60%60suggestion%0A%20%20%20%20if%20%28reducedMotion%29%20%7B%0A%20%20%20%20%20%20setValue%28target%29%3B%0A%20%20%20%20%20%20return%3B%0A%20%20%20%20%7D%0A%20%20%20%20setValue%280%29%3B%0A%20%20%20%20let%20raf%20%3D%200%3B%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ishannaik%2Fwarp&pr=192&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ishannaik%2Fwarp%22%20on%20the%20existing%20branch%20%22fix%2Fstats-reduced-motion-184%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fstats-reduced-motion-184%22.%0A%0A%23%23%23%20Issue%201%0Aweb%2Fsrc%2Fsections%2FStats.tsx%3A25-29%0AWhen%20%60reducedMotion%60%20flips%20from%20%60true%60%20%E2%86%92%20%60false%60%20while%20the%20section%20is%20already%20in%20view%2C%20the%20state%20%60value%60%20is%20already%20at%20%60target%60%20%28from%20the%20snap%29.%20The%20first%20%60tick%60%20call%20immediately%20writes%20%60setValue%28target%20*%20easeOutCubic%280%29%29%20%3D%3D%3D%20setValue%280%29%60%2C%20causing%20a%20one-frame%20flash%20of%20the%20final%20value%20%E2%86%92%200%20%E2%86%92%20counting%20back%20up.%20Resetting%20state%20to%200%20before%20starting%20the%20animation%20prevents%20this.%0A%0A%60%60%60suggestion%0A%20%20%20%20if%20%28reducedMotion%29%20%7B%0A%20%20%20%20%20%20setValue%28target%29%3B%0A%20%20%20%20%20%20return%3B%0A%20%20%20%20%7D%0A%20%20%20%20setValue%280%29%3B%0A%20%20%20%20let%20raf%20%3D%200%3B%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ishannaik%2Fwarp&pr=192&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Aweb%2Fsrc%2Fsections%2FStats.tsx%3A25-29%0AWhen%20%60reducedMotion%60%20flips%20from%20%60true%60%20%E2%86%92%20%60false%60%20while%20the%20section%20is%20already%20in%20view%2C%20the%20state%20%60value%60%20is%20already%20at%20%60target%60%20%28from%20the%20snap%29.%20The%20first%20%60tick%60%20call%20immediately%20writes%20%60setValue%28target%20*%20easeOutCubic%280%29%29%20%3D%3D%3D%20setValue%280%29%60%2C%20causing%20a%20one-frame%20flash%20of%20the%20final%20value%20%E2%86%92%200%20%E2%86%92%20counting%20back%20up.%20Resetting%20state%20to%200%20before%20starting%20the%20animation%20prevents%20this.%0A%0A%60%60%60suggestion%0A%20%20%20%20if%20%28reducedMotion%29%20%7B%0A%20%20%20%20%20%20setValue%28target%29%3B%0A%20%20%20%20%20%20return%3B%0A%20%20%20%20%7D%0A%20%20%20%20setValue%280%29%3B%0A%20%20%20%20let%20raf%20%3D%200%3B%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=192&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/sections/Stats.tsx:25-29
When `reducedMotion` flips from `true` → `false` while the section is already in view, the state `value` is already at `target` (from the snap). The first `tick` call immediately writes `setValue(target * easeOutCubic(0)) === setValue(0)`, causing a one-frame flash of the final value → 0 → counting back up. Resetting state to 0 before starting the animation prevents this.

```suggestion
    if (reducedMotion) {
      setValue(target);
      return;
    }
    setValue(0);
    let raf = 0;
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["a11y(stats): snap count-up when prefers-..."](https://github.com/ishannaik/warp/commit/7b76c222b4a44e22b1cda3d86cb49085f983c4f2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49952472)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->