### PR TITLE
docs: replace leftover Wrap product name in web/src comments

### DIFF
--- a/web/src/hero/Atmosphere.tsx
+++ b/web/src/hero/Atmosphere.tsx
@@ -2,7 +2,7 @@ import type { CSSProperties } from "react";
 
 /**
  * Hero background atmosphere layer: an aceternity-style lamp glow plus a set of
- * magic-ui meteor streaks. Ported verbatim from the Wrap design source
+ * magic-ui meteor streaks. Ported verbatim from the Warp design source
  * (`#warp-atmo`). Pointer-events disabled; sits behind the hero content.
  *
  * The shipped default variant has atmosphere ON, so this is always rendered.

--- a/web/src/hero/Hero.tsx
+++ b/web/src/hero/Hero.tsx
@@ -6,7 +6,7 @@ import WarpLogo from "../WarpLogo";
 import { useIsMobile } from "../lib/useIsMobile";
 
 /**
- * Hero composition for the Wrap landing page. Ported verbatim from the design
+ * Hero composition for the Warp landing page. Ported verbatim from the design
  * source: corner crosshairs, status strip, nav, the hero grid (copy + the
  * ShareX transfer window), and the marquee ticker. The atmosphere layer (lamp
  * + meteors) is rendered as the background.

--- a/web/src/hero/TransferWindow.tsx
+++ b/web/src/hero/TransferWindow.tsx
@@ -6,7 +6,7 @@ import { useIsMobile } from "../lib/useIsMobile";
 
 /**
  * ShareX-style transfer-queue window for the hero (right column).
- * Ported verbatim from the Wrap design source: magic-ui border beam,
+ * Ported verbatim from the Warp design source: magic-ui border beam,
  * Queue / History / Peers tabs, the animated queue rows, and the footer
  * totals. Tab switching is reimplemented here as React state; the Live-mode
  * queue simulation lives in the useTransferSim() hook.

--- a/web/src/hero/useTransferSim.ts
+++ b/web/src/hero/useTransferSim.ts
@@ -4,7 +4,7 @@ import { useReducedMotion } from "../lib/useReducedMotion";
 /**
  * Live-mode transfer simulation (the "ShareX queue" behaviour).
  *
- * Ported verbatim from the Wrap design export's vanilla-JS `tick()`:
+ * Ported verbatim from the Warp design export's vanilla-JS `tick()`:
  *   - interval 130ms, multiplier 1, throughput multiplier 1  (Live mode)
  *   - uploading rows advance pct by (bytes>3000 ? 0.9 : 1.7) * (0.6 + rand*0.9) * mult
  *   - when fewer than 2 rows are uploading, the next queued row is promoted

--- a/web/src/lib/theme.ts
+++ b/web/src/lib/theme.ts
@@ -1,7 +1,7 @@
 import type { CSSProperties } from "react";
 
 /**
- * Accent palettes ported verbatim from the Wrap design source.
+ * Accent palettes ported verbatim from the Warp design source.
  * The shipped default variant is `Ultramarine`.
  */
 export interface Palette {
@@ -21,7 +21,7 @@ export const PALETTES = {
 export type PaletteName = keyof typeof PALETTES;
 
 /**
- * Channel-activity modes ported verbatim from the Wrap design source.
+ * Channel-activity modes ported verbatim from the Warp design source.
  * The shipped default variant is `Live`.
  *
  * - `i`    : simulation tick interval in ms

--- a/web/src/lib/warp/signaling.ts
+++ b/web/src/lib/warp/signaling.ts
@@ -1,5 +1,5 @@
 /**
- * Typed client for the Wrap signaling server.
+ * Typed client for the Warp signaling server.
  *
  * Transport: a single WebSocket to the live Cloudflare Worker. The server is a
  * dumb relay — it assigns a `selfId`, owns rooms, and forwards opaque `signal`

--- a/web/src/lib/warp/useWarpTransfer.ts
+++ b/web/src/lib/warp/useWarpTransfer.ts
@@ -1,5 +1,5 @@
 /**
- * React hook orchestrating a Wrap transfer: signaling socket, the WebRTC peers,
+ * React hook orchestrating a Warp transfer: signaling socket, the WebRTC peers,
  * and the symmetric file-transfer tray. Both sender and receiver use this hook —
  * pass `joinCode` to act as the receiver who joins an existing room.
  *

--- a/web/src/nearby/NearbyDevices.tsx
+++ b/web/src/nearby/NearbyDevices.tsx
@@ -8,7 +8,7 @@ import { useNearbyTransfer, type NearbyDevice } from "./useNearbyTransfer";
 /**
  * "On your network" — LAN auto-discovery surface for the landing page.
  *
- * Lists other Wrap devices on the same Wi-Fi (no code needed). Tap a device to
+ * Lists other Warp devices on the same Wi-Fi (no code needed). Tap a device to
  * pick files and offer them across. Review-before-receive redesign: an inbound
  * FILE offer raises the SAME accept modal as the code-room flow (with the file
  * manifest, thumbnails, sizes), and on accept the files land in an in-app TRAY

--- a/web/src/receive/ReceiveEntry.tsx
+++ b/web/src/receive/ReceiveEntry.tsx
@@ -10,7 +10,7 @@ import { CODE_LEN, VALID_RE, sanitize } from "../lib/warp/roomCode";
  * isn't tappable). One field, auto-uppercased and sanitised to the server's
  * code alphabet, then `navigate("/r/<CODE>")` hands off to TransferFlow.
  *
- * Built from the existing Wrap design system — same dark palette, hairline
+ * Built from the existing Warp design system — same dark palette, hairline
  * borders, mono labels, Bricolage/Archivo/JetBrains Mono fonts, accent button.
  */
 

--- a/web/src/sections/Compare.tsx
+++ b/web/src/sections/Compare.tsx
@@ -3,8 +3,8 @@ import { useIsMobile } from "../lib/useIsMobile";
 
 /**
  * Section 04 — "How it compares".
- * Comparison table of Wrap vs AirDrop / WeTransfer / Wormhole.
- * Ported verbatim from the Wrap design source (#compare).
+ * Comparison table of Warp vs AirDrop / WeTransfer / Wormhole.
+ * Ported verbatim from the Warp design source (#compare).
  */
 
 const CHECK = "✓"; // ✓

--- a/web/src/sections/Faq.tsx
+++ b/web/src/sections/Faq.tsx
@@ -3,7 +3,7 @@ import { useIsMobile } from "../lib/useIsMobile";
 
 /**
  * Section 05 — "Questions".
- * Accordion of the five honest answers, ported verbatim from the Wrap
+ * Accordion of the five honest answers, ported verbatim from the Warp
  * design source (#faq).
  *
  * The source used a vanilla-JS max-height toggle; here a single open index is

--- a/web/src/sections/FooterCta.tsx
+++ b/web/src/sections/FooterCta.tsx
@@ -4,7 +4,7 @@ import { useIsMobile } from "../lib/useIsMobile";
 
 /**
  * FooterCta — closing call-to-action + footer bar.
- * Ported verbatim from the Wrap design export (FOOTER CTA section):
+ * Ported verbatim from the Warp design export (FOOTER CTA section):
  *  - giant masked <h2> "Send it / straight through." with accent glow
  *  - "Start a transfer →" button
  *  - footer chrome: wordmark, links, "MIT LICENSED · MADE FOR THE OPEN WEB"

--- a/web/src/styles/keyframes.css
+++ b/web/src/styles/keyframes.css
@@ -1,4 +1,4 @@
-/* All @keyframes ported verbatim from the Wrap design source. Do not redefine elsewhere. */
+/* All @keyframes ported verbatim from the Warp design source. Do not redefine elsewhere. */
 
 @keyframes warpRise {
   from {

--- a/web/src/theory/Theory.tsx
+++ b/web/src/theory/Theory.tsx
@@ -34,11 +34,11 @@ import L7Bedrock from "./diagrams/L7Bedrock";
 /**
  * Theory — the "/how" deep-dive (page shell / foundation).
  *
- * Editorial technical longform that teaches (PART A) how Wrap actually works,
+ * Editorial technical longform that teaches (PART A) how Warp actually works,
  * concept by concept, then descends (PART B) through the economics of a relayed
  * byte to show why a relay can never be truly free.
  *
- * Built entirely on the Wrap design system: dark palette, Bricolage/Archivo/
+ * Built entirely on the Warp design system: dark palette, Bricolage/Archivo/
  * JetBrains Mono, hairline borders, mono eyebrows, accent var(--acc) /
  * amber var(--amb). All diagrams are self-contained CSS/SVG components living in
  * ./diagrams and rendered beside their prose. Final copy comes from

--- a/web/src/theory/diagrams/L0Direct.tsx
+++ b/web/src/theory/diagrams/L0Direct.tsx
@@ -35,7 +35,7 @@ export default function L0Direct() {
   const accLine = "rgba(83,96,255,.55)";
 
   /* A faint, pre-existing access link. Drawn as a dim dashed stub with a
-     "sunk cost / flat rate" tag — it exists whether or not Wrap uses it. */
+     "sunk cost / flat rate" tag — it exists whether or not Warp uses it. */
   function AccessStub({ tag, align }: { tag: string; align: "left" | "right" }) {
     return (
       <div

--- a/web/src/theory/diagrams/L2Edge.tsx
+++ b/web/src/theory/diagrams/L2Edge.tsx
@@ -21,7 +21,7 @@ import {
  * Contrasts two workloads through an edge node:
  *  - Cacheable (cheap): one origin fetch, then many cache HITs fan out; the
  *    hit counter climbs while cost-per-delivery collapses (a flat-cheap curve).
- *  - Wrap-style transfer (not cacheable): every request is a unique encrypted
+ *  - Warp-style transfer (not cacheable): every request is a unique encrypted
  *    MISS; the egress meter climbs one-for-one (a linear curve).
  *
  * The two cost curves are drawn as SVG and animate their divergence.

--- a/web/src/theory/diagrams/NatStun.tsx
+++ b/web/src/theory/diagrams/NatStun.tsx
@@ -21,7 +21,7 @@ import {
  *  - SYMMETRIC / CGNAT (amber, failure): the NAT assigns a DIFFERENT outbound
  *    port per destination (:51001 → :51002 → :51003). The address STUN learned
  *    no longer matches; the hole-punch fails (broken beam) — the ball hits the
- *    wall. Only a TURN relay could bridge it — and Wrap won't.
+ *    wall. Only a TURN relay could bridge it — and Warp won't.
  *
  * Beneath: the ~10–20% "needs a relay" bar — the hinge into PART B.
  *

--- a/web/src/theory/diagrams/primitives.tsx
+++ b/web/src/theory/diagrams/primitives.tsx
@@ -13,7 +13,7 @@ import {
  * Every diagram in src/theory/diagrams reuses these so the deep-dive reads as
  * one consistent visual language: the same node chrome, the same beams, the
  * same labels, the same scroll-trigger. All pieces are CSS/SVG only (no raster
- * images) and lean on the Wrap palette tokens (--acc, --amb, ink/body/muted/
+ * images) and lean on the Warp palette tokens (--acc, --amb, ink/body/muted/
  * dim) plus the theory.css keyframes.
  *
  * Convention: diagrams import what they need from "./primitives" and wrap their

--- a/web/src/transfer/TransferFlow.tsx
+++ b/web/src/transfer/TransferFlow.tsx
@@ -10,7 +10,7 @@ import { copyToClipboard } from "../lib/copyToClipboard";
 import { AcceptModal, SessionView } from "./SessionView";
 
 /**
- * Wrap Transfer flow — a real, WebRTC-backed transfer surface.
+ * Warp Transfer flow — a real, WebRTC-backed transfer surface.
  *
  * Review-before-receive redesign: there are now two pre-connect screens and then
  * one PERSISTENT session view shared with the LAN flow:


### PR DESCRIPTION
## Summary
- Replace leftover product name "Wrap" with "Warp" in web/src module headers and comments (closes #183)
- Comment-only; identifiers / flexWrap / Cloudflare project `wrap` untouched

## Test plan
- [ ] `rg -n '\bWrap\b' web/src` has no product-name hits left (layout words fine)
- [ ] No runtime changes

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a leftover branding typo by replacing every instance of "Wrap" (the old product name) with "Warp" (the correct brand) across 19 comment blocks and JSDoc headers in `web/src`. No identifiers, CSS layout properties, or the Cloudflare Pages project name (`wrap`) are touched.

- Corrects module-level JSDoc in hero, lib, nearby, receive, sections, theory, and transfer files.
- Updates the single CSS file-header comment in `keyframes.css`.
- Leaves all `flexWrap`/`overflowWrap` layout identifiers and the internal `wrap` Cloudflare project name intact, matching the guidance in `CLAUDE.md`.
</details>

<h3>Confidence Score: 5/5</h3>

Comment-only changes with no runtime impact; safe to merge as-is.

Every changed line is inside a JSDoc block or a CSS comment. No executable code, types, identifiers, or styles were touched. A post-merge grep confirms no stray "Wrap" product-name occurrences remain in web/src.

**Files Needing Attention:** No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/src/hero/Atmosphere.tsx | Comment-only: "Wrap design source" → "Warp design source" in JSDoc header. |
| web/src/hero/Hero.tsx | Comment-only: "Wrap landing page" → "Warp landing page" in JSDoc header. |
| web/src/hero/TransferWindow.tsx | Comment-only: "Wrap design source" → "Warp design source" in JSDoc header. |
| web/src/hero/useTransferSim.ts | Comment-only: "Wrap design export" → "Warp design export" in JSDoc header. |
| web/src/lib/theme.ts | Comment-only: two JSDoc occurrences of "Wrap design source" corrected to "Warp design source". |
| web/src/lib/warp/signaling.ts | Comment-only: "Wrap signaling server" → "Warp signaling server" in module-level JSDoc. |
| web/src/lib/warp/useWarpTransfer.ts | Comment-only: "Wrap transfer" → "Warp transfer" in hook JSDoc; no identifier changes. |
| web/src/styles/keyframes.css | Comment-only: file-header CSS comment corrected from "Wrap" to "Warp"; keyframe names unchanged. |
| web/src/theory/Theory.tsx | Comment-only: two occurrences of "Wrap" corrected to "Warp" in the module JSDoc. |
| web/src/transfer/TransferFlow.tsx | Comment-only: "Wrap Transfer flow" → "Warp Transfer flow" in JSDoc header. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["19 files in web/src"] --> B{"Comment or identifier?"}
    B -->|"Comment / JSDoc"| C["'Wrap' → 'Warp' ✓"]
    B -->|"Identifier / CSS property"| D["Left untouched ✓\n(flexWrap, overflowWrap, …)"]
    B -->|"Cloudflare project name"| E["'wrap' left untouched ✓\n(--project-name=wrap)"]
    C --> F["No runtime change"]
    D --> F
    E --> F
```
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: fix remaining Wrap mention in Faq ..."](https://github.com/ishannaik/warp/commit/5bf92094c01823ddf1d267540ad5d284db3a729e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49952487)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/ishannaik/github/Ishannaik/warp/-/custom-context?memory=575c40ec-32b8-4814-a2b7-1ced5808ec85))

<!-- /greptile_comment -->