### PR TITLE
fix(a11y): connect FAQ triggers to panels

### DIFF
--- a/web/src/sections/Faq.tsx
+++ b/web/src/sections/Faq.tsx
@@ -132,11 +132,13 @@ export default function Faq() {
         <div style={{ borderTop: "1px solid rgba(239,233,218,.16)" }}>
           {ITEMS.map((item, i) => {
             const open = openIndex === i;
+            const panelId = `faq-panel-${i}`;
             return (
               <div key={item.q} style={itemStyle}>
                 <button
                   type="button"
                   aria-expanded={open}
+                  aria-controls={panelId}
                   style={{
                     ...triggerStyle,
                     gap: isMobile ? "12px" : triggerStyle.gap,
@@ -164,6 +166,7 @@ export default function Faq() {
                   </span>
                 </button>
                 <div
+                  id={panelId}
                   style={{
                     display: "grid",
                     gridTemplateRows: open ? "1fr" : "0fr",


### PR DESCRIPTION
## What & why

Closes #185

Each FAQ trigger now points to its answer panel with `aria-controls`, and each panel has the matching stable `id`. The existing accordion state, animation, and mobile styles are unchanged.

## Type

- [x] fix

## Checklist

- [x] `pnpm lint && pnpm typecheck` pass locally
- [x] `pnpm --filter @warp/web build` is green
- [ ] `pnpm --filter @warp/server test` not applicable (web-only change)
- [ ] Engine checks not applicable
- [ ] Existing `useIsMobile()` branch and 360–430px styles preserved; browser device-toolbar check remains for maintainer review
- [x] Design tokens and inline-style component style respected

### Hard constraints

- [x] No infrastructure or dependency changes
- [x] STUN-only behavior untouched
- [x] Signaling behavior untouched
- [x] `SEND_HIGH_WATER` untouched
- [x] Transfer recovery and keepalive untouched

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Improved FAQ accordion navigation by linking each question to its corresponding answer panel for assistive technologies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR wires up the ARIA relationship between FAQ accordion triggers and their panels by adding `aria-controls` to each trigger button and a matching `id` to each panel wrapper div, fixing issue #185.

- `panelId` is derived from the map index (`faq-panel-{i}`); since `ITEMS` is a static constant this is stable, but index-based IDs would break if items were ever reordered or filtered dynamically.
- The panel is always present in the DOM and is hidden only via a CSS grid-row trick (`gridTemplateRows: "0fr"` + `overflow: hidden`), without `display: none` or the HTML `hidden` attribute — collapsed content may still be traversed by some screen readers despite `aria-expanded="false"` on the trigger.
- For full WAI-ARIA Accordion compliance the panel should also carry `role="region"` and `aria-labelledby` pointing back to the trigger button's `id`, completing the two-way association.
</details>


<h3>Confidence Score: 4/5</h3>

The change is narrowly scoped to two attribute additions in the FAQ accordion. Existing accordion state, animation, and mobile styles are untouched. The main watch-out is the CSS-only collapse approach, which may leave content exposed to screen readers when closed.

The aria-controls/id wiring is correct and the IDs are stable for the current static dataset. However, the panel collapse is achieved purely with gridTemplateRows: 0fr and overflow: hidden — no hidden attribute or display: none — so screen readers that do not respect the grid sizing trick can still read collapsed answers while the button announces aria-expanded=false, which is a real accessibility inconsistency now that the trigger-panel relationship is formally declared.

**Files Needing Attention:** web/src/sections/Faq.tsx — specifically the inner content div inside each collapsed panel, which has no mechanism to hide itself from the accessibility tree.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/src/sections/Faq.tsx | Adds `aria-controls` on each FAQ trigger button and a matching `id` on each panel div. IDs are index-based but stable (ITEMS is a static constant). Panel visibility relies on CSS grid row sizing without `display:none`/`hidden`, which may expose collapsed content to some screen readers. |


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["FAQ trigger button\naria-expanded={open}\naria-controls='faq-panel-{i}'"] -->|"aria-controls references"| B["Panel wrapper div\nid='faq-panel-{i}'"]
    B --> C["Inner div\noverflow: hidden"]
    C --> D["Answer paragraph"]

    A -->|"onClick"| E{open?}
    E -->|"yes → close"| F["setOpenIndex(null)\ngridTemplateRows: 0fr"]
    E -->|"no → open"| G["setOpenIndex(i)\ngridTemplateRows: 1fr"]

    style A fill:#5360ff,color:#fff
    style B fill:#3a3832,color:#efe9da
    style F fill:#121110,color:#a8a293
    style G fill:#121110,color:#a8a293
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `web/src/sections/Faq.tsx`, line 168-175 ([link](https://github.com/ishannaik/warp/blob/dd8b4997d79348814091d2dbcf8cd51d819d0304/web/src/sections/Faq.tsx#L168-L175)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Collapsed content may still be read by screen readers**

   The panel is always in the DOM and hidden only through a CSS grid trick (`gridTemplateRows: "0fr"` + `overflow: hidden`). This does not add `display: none`, `visibility: hidden`, or the HTML `hidden` attribute, so some screen readers (particularly VoiceOver and NVDA) may traverse and read the collapsed answer text even when `aria-expanded="false"` on the trigger says it is closed. Adding `hidden` to the inner content `div` when the item is not open — and removing it during the open state — would hide the content from the accessibility tree while still allowing the grid-row CSS transition to animate (the outer animated wrapper keeps its `id` and stays in the DOM).

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: web/src/sections/Faq.tsx
   Line: 168-175

   Comment:
   **Collapsed content may still be read by screen readers**

   The panel is always in the DOM and hidden only through a CSS grid trick (`gridTemplateRows: "0fr"` + `overflow: hidden`). This does not add `display: none`, `visibility: hidden`, or the HTML `hidden` attribute, so some screen readers (particularly VoiceOver and NVDA) may traverse and read the collapsed answer text even when `aria-expanded="false"` on the trigger says it is closed. Adding `hidden` to the inner content `div` when the item is not open — and removing it during the open state — would hide the content from the accessibility tree while still allowing the grid-row CSS transition to animate (the outer animated wrapper keeps its `id` and stays in the DOM).

   ---

   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20web%2Fsrc%2Fsections%2FFaq.tsx%0ALine%3A%20168-175%0A%0AComment%3A%0A**Collapsed%20content%20may%20still%20be%20read%20by%20screen%20readers**%0A%0AThe%20panel%20is%20always%20in%20the%20DOM%20and%20hidden%20only%20through%20a%20CSS%20grid%20trick%20%28%60gridTemplateRows%3A%20%220fr%22%60%20%2B%20%60overflow%3A%20hidden%60%29.%20This%20does%20not%20add%20%60display%3A%20none%60%2C%20%60visibility%3A%20hidden%60%2C%20or%20the%20HTML%20%60hidden%60%20attribute%2C%20so%20some%20screen%20readers%20%28particularly%20VoiceOver%20and%20NVDA%29%20may%20traverse%20and%20read%20the%20collapsed%20answer%20text%20even%20when%20%60aria-expanded%3D%22false%22%60%20on%20the%20trigger%20says%20it%20is%20closed.%20Adding%20%60hidden%60%20to%20the%20inner%20content%20%60div%60%20when%20the%20item%20is%20not%20open%20%E2%80%94%20and%20removing%20it%20during%20the%20open%20state%20%E2%80%94%20would%20hide%20the%20content%20from%20the%20accessibility%20tree%20while%20still%20allowing%20the%20grid-row%20CSS%20transition%20to%20animate%20%28the%20outer%20animated%20wrapper%20keeps%20its%20%60id%60%20and%20stays%20in%20the%20DOM%29.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ishannaik%2Fwarp&pr=194&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ishannaik%2Fwarp%22%20on%20the%20existing%20branch%20%22fix%2Ffaq-aria-controls%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Ffaq-aria-controls%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20web%2Fsrc%2Fsections%2FFaq.tsx%0ALine%3A%20168-175%0A%0AComment%3A%0A**Collapsed%20content%20may%20still%20be%20read%20by%20screen%20readers**%0A%0AThe%20panel%20is%20always%20in%20the%20DOM%20and%20hidden%20only%20through%20a%20CSS%20grid%20trick%20%28%60gridTemplateRows%3A%20%220fr%22%60%20%2B%20%60overflow%3A%20hidden%60%29.%20This%20does%20not%20add%20%60display%3A%20none%60%2C%20%60visibility%3A%20hidden%60%2C%20or%20the%20HTML%20%60hidden%60%20attribute%2C%20so%20some%20screen%20readers%20%28particularly%20VoiceOver%20and%20NVDA%29%20may%20traverse%20and%20read%20the%20collapsed%20answer%20text%20even%20when%20%60aria-expanded%3D%22false%22%60%20on%20the%20trigger%20says%20it%20is%20closed.%20Adding%20%60hidden%60%20to%20the%20inner%20content%20%60div%60%20when%20the%20item%20is%20not%20open%20%E2%80%94%20and%20removing%20it%20during%20the%20open%20state%20%E2%80%94%20would%20hide%20the%20content%20from%20the%20accessibility%20tree%20while%20still%20allowing%20the%20grid-row%20CSS%20transition%20to%20animate%20%28the%20outer%20animated%20wrapper%20keeps%20its%20%60id%60%20and%20stays%20in%20the%20DOM%29.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ishannaik%2Fwarp&pr=194&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20web%2Fsrc%2Fsections%2FFaq.tsx%0ALine%3A%20168-175%0A%0AComment%3A%0A**Collapsed%20content%20may%20still%20be%20read%20by%20screen%20readers**%0A%0AThe%20panel%20is%20always%20in%20the%20DOM%20and%20hidden%20only%20through%20a%20CSS%20grid%20trick%20%28%60gridTemplateRows%3A%20%220fr%22%60%20%2B%20%60overflow%3A%20hidden%60%29.%20This%20does%20not%20add%20%60display%3A%20none%60%2C%20%60visibility%3A%20hidden%60%2C%20or%20the%20HTML%20%60hidden%60%20attribute%2C%20so%20some%20screen%20readers%20%28particularly%20VoiceOver%20and%20NVDA%29%20may%20traverse%20and%20read%20the%20collapsed%20answer%20text%20even%20when%20%60aria-expanded%3D%22false%22%60%20on%20the%20trigger%20says%20it%20is%20closed.%20Adding%20%60hidden%60%20to%20the%20inner%20content%20%60div%60%20when%20the%20item%20is%20not%20open%20%E2%80%94%20and%20removing%20it%20during%20the%20open%20state%20%E2%80%94%20would%20hide%20the%20content%20from%20the%20accessibility%20tree%20while%20still%20allowing%20the%20grid-row%20CSS%20transition%20to%20animate%20%28the%20outer%20animated%20wrapper%20keeps%20its%20%60id%60%20and%20stays%20in%20the%20DOM%29.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=194&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a>


2. `web/src/sections/Faq.tsx`, line 168-174 ([link](https://github.com/ishannaik/warp/blob/dd8b4997d79348814091d2dbcf8cd51d819d0304/web/src/sections/Faq.tsx#L168-L174)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> Pair the `role="region"` and `aria-labelledby` on the panel wrapper to match the trigger button id added above. This completes the two-way association recommended by WAI-ARIA for accordion patterns.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: web/src/sections/Faq.tsx
   Line: 168-174

   Comment:
   Pair the `role="region"` and `aria-labelledby` on the panel wrapper to match the trigger button id added above. This completes the two-way association recommended by WAI-ARIA for accordion patterns.

   

   ---

   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20web%2Fsrc%2Fsections%2FFaq.tsx%0ALine%3A%20168-174%0A%0AComment%3A%0APair%20the%20%60role%3D%22region%22%60%20and%20%60aria-labelledby%60%20on%20the%20panel%20wrapper%20to%20match%20the%20trigger%20button%20id%20added%20above.%20This%20completes%20the%20two-way%20association%20recommended%20by%20WAI-ARIA%20for%20accordion%20patterns.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3Cdiv%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20id%3D%7BpanelId%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20role%3D%22region%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20aria-labelledby%3D%7B%60faq-trigger-%24%7Bi%7D%60%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20style%3D%7B%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20display%3A%20%22grid%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20gridTemplateRows%3A%20open%20%3F%20%221fr%22%20%3A%20%220fr%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20transition%3A%20%22grid-template-rows%20.35s%20ease%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%7D%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ishannaik%2Fwarp&pr=194&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ishannaik%2Fwarp%22%20on%20the%20existing%20branch%20%22fix%2Ffaq-aria-controls%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Ffaq-aria-controls%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20web%2Fsrc%2Fsections%2FFaq.tsx%0ALine%3A%20168-174%0A%0AComment%3A%0APair%20the%20%60role%3D%22region%22%60%20and%20%60aria-labelledby%60%20on%20the%20panel%20wrapper%20to%20match%20the%20trigger%20button%20id%20added%20above.%20This%20completes%20the%20two-way%20association%20recommended%20by%20WAI-ARIA%20for%20accordion%20patterns.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3Cdiv%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20id%3D%7BpanelId%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20role%3D%22region%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20aria-labelledby%3D%7B%60faq-trigger-%24%7Bi%7D%60%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20style%3D%7B%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20display%3A%20%22grid%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20gridTemplateRows%3A%20open%20%3F%20%221fr%22%20%3A%20%220fr%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20transition%3A%20%22grid-template-rows%20.35s%20ease%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%7D%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ishannaik%2Fwarp&pr=194&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20web%2Fsrc%2Fsections%2FFaq.tsx%0ALine%3A%20168-174%0A%0AComment%3A%0APair%20the%20%60role%3D%22region%22%60%20and%20%60aria-labelledby%60%20on%20the%20panel%20wrapper%20to%20match%20the%20trigger%20button%20id%20added%20above.%20This%20completes%20the%20two-way%20association%20recommended%20by%20WAI-ARIA%20for%20accordion%20patterns.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3Cdiv%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20id%3D%7BpanelId%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20role%3D%22region%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20aria-labelledby%3D%7B%60faq-trigger-%24%7Bi%7D%60%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20style%3D%7B%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20display%3A%20%22grid%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20gridTemplateRows%3A%20open%20%3F%20%221fr%22%20%3A%20%220fr%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20transition%3A%20%22grid-template-rows%20.35s%20ease%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%7D%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=194&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aweb%2Fsrc%2Fsections%2FFaq.tsx%3A168-175%0A**Collapsed%20content%20may%20still%20be%20read%20by%20screen%20readers**%0A%0AThe%20panel%20is%20always%20in%20the%20DOM%20and%20hidden%20only%20through%20a%20CSS%20grid%20trick%20%28%60gridTemplateRows%3A%20%220fr%22%60%20%2B%20%60overflow%3A%20hidden%60%29.%20This%20does%20not%20add%20%60display%3A%20none%60%2C%20%60visibility%3A%20hidden%60%2C%20or%20the%20HTML%20%60hidden%60%20attribute%2C%20so%20some%20screen%20readers%20%28particularly%20VoiceOver%20and%20NVDA%29%20may%20traverse%20and%20read%20the%20collapsed%20answer%20text%20even%20when%20%60aria-expanded%3D%22false%22%60%20on%20the%20trigger%20says%20it%20is%20closed.%20Adding%20%60hidden%60%20to%20the%20inner%20content%20%60div%60%20when%20the%20item%20is%20not%20open%20%E2%80%94%20and%20removing%20it%20during%20the%20open%20state%20%E2%80%94%20would%20hide%20the%20content%20from%20the%20accessibility%20tree%20while%20still%20allowing%20the%20grid-row%20CSS%20transition%20to%20animate%20%28the%20outer%20animated%20wrapper%20keeps%20its%20%60id%60%20and%20stays%20in%20the%20DOM%29.%0A%0A%23%23%23%20Issue%202%0Aweb%2Fsrc%2Fsections%2FFaq.tsx%3A138-142%0AFor%20full%20WAI-ARIA%20Accordion%20compliance%2C%20the%20panel%20should%20have%20%60role%3D%22region%22%60%20and%20%60aria-labelledby%60%20pointing%20back%20to%20its%20trigger%20button.%20This%20lets%20screen%20readers%20announce%20the%20section%20heading%20when%20navigating%20into%20the%20panel.%20This%20also%20requires%20adding%20an%20%60id%60%20to%20the%20button%20element.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3Cbutton%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20id%3D%7B%60faq-trigger-%24%7Bi%7D%60%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20type%3D%22button%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20aria-expanded%3D%7Bopen%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20aria-controls%3D%7BpanelId%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20style%3D%7B%7B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%0Aweb%2Fsrc%2Fsections%2FFaq.tsx%3A168-174%0APair%20the%20%60role%3D%22region%22%60%20and%20%60aria-labelledby%60%20on%20the%20panel%20wrapper%20to%20match%20the%20trigger%20button%20id%20added%20above.%20This%20completes%20the%20two-way%20association%20recommended%20by%20WAI-ARIA%20for%20accordion%20patterns.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3Cdiv%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20id%3D%7BpanelId%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20role%3D%22region%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20aria-labelledby%3D%7B%60faq-trigger-%24%7Bi%7D%60%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20style%3D%7B%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20display%3A%20%22grid%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20gridTemplateRows%3A%20open%20%3F%20%221fr%22%20%3A%20%220fr%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20transition%3A%20%22grid-template-rows%20.35s%20ease%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%7D%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ishannaik%2Fwarp&pr=194&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ishannaik%2Fwarp%22%20on%20the%20existing%20branch%20%22fix%2Ffaq-aria-controls%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Ffaq-aria-controls%22.%0A%0A%23%23%23%20Issue%201%0Aweb%2Fsrc%2Fsections%2FFaq.tsx%3A168-175%0A**Collapsed%20content%20may%20still%20be%20read%20by%20screen%20readers**%0A%0AThe%20panel%20is%20always%20in%20the%20DOM%20and%20hidden%20only%20through%20a%20CSS%20grid%20trick%20%28%60gridTemplateRows%3A%20%220fr%22%60%20%2B%20%60overflow%3A%20hidden%60%29.%20This%20does%20not%20add%20%60display%3A%20none%60%2C%20%60visibility%3A%20hidden%60%2C%20or%20the%20HTML%20%60hidden%60%20attribute%2C%20so%20some%20screen%20readers%20%28particularly%20VoiceOver%20and%20NVDA%29%20may%20traverse%20and%20read%20the%20collapsed%20answer%20text%20even%20when%20%60aria-expanded%3D%22false%22%60%20on%20the%20trigger%20says%20it%20is%20closed.%20Adding%20%60hidden%60%20to%20the%20inner%20content%20%60div%60%20when%20the%20item%20is%20not%20open%20%E2%80%94%20and%20removing%20it%20during%20the%20open%20state%20%E2%80%94%20would%20hide%20the%20content%20from%20the%20accessibility%20tree%20while%20still%20allowing%20the%20grid-row%20CSS%20transition%20to%20animate%20%28the%20outer%20animated%20wrapper%20keeps%20its%20%60id%60%20and%20stays%20in%20the%20DOM%29.%0A%0A%23%23%23%20Issue%202%0Aweb%2Fsrc%2Fsections%2FFaq.tsx%3A138-142%0AFor%20full%20WAI-ARIA%20Accordion%20compliance%2C%20the%20panel%20should%20have%20%60role%3D%22region%22%60%20and%20%60aria-labelledby%60%20pointing%20back%20to%20its%20trigger%20button.%20This%20lets%20screen%20readers%20announce%20the%20section%20heading%20when%20navigating%20into%20the%20panel.%20This%20also%20requires%20adding%20an%20%60id%60%20to%20the%20button%20element.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3Cbutton%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20id%3D%7B%60faq-trigger-%24%7Bi%7D%60%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20type%3D%22button%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20aria-expanded%3D%7Bopen%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20aria-controls%3D%7BpanelId%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20style%3D%7B%7B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%0Aweb%2Fsrc%2Fsections%2FFaq.tsx%3A168-174%0APair%20the%20%60role%3D%22region%22%60%20and%20%60aria-labelledby%60%20on%20the%20panel%20wrapper%20to%20match%20the%20trigger%20button%20id%20added%20above.%20This%20completes%20the%20two-way%20association%20recommended%20by%20WAI-ARIA%20for%20accordion%20patterns.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3Cdiv%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20id%3D%7BpanelId%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20role%3D%22region%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20aria-labelledby%3D%7B%60faq-trigger-%24%7Bi%7D%60%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20style%3D%7B%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20display%3A%20%22grid%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20gridTemplateRows%3A%20open%20%3F%20%221fr%22%20%3A%20%220fr%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20transition%3A%20%22grid-template-rows%20.35s%20ease%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%7D%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ishannaik%2Fwarp&pr=194&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Aweb%2Fsrc%2Fsections%2FFaq.tsx%3A168-175%0A**Collapsed%20content%20may%20still%20be%20read%20by%20screen%20readers**%0A%0AThe%20panel%20is%20always%20in%20the%20DOM%20and%20hidden%20only%20through%20a%20CSS%20grid%20trick%20%28%60gridTemplateRows%3A%20%220fr%22%60%20%2B%20%60overflow%3A%20hidden%60%29.%20This%20does%20not%20add%20%60display%3A%20none%60%2C%20%60visibility%3A%20hidden%60%2C%20or%20the%20HTML%20%60hidden%60%20attribute%2C%20so%20some%20screen%20readers%20%28particularly%20VoiceOver%20and%20NVDA%29%20may%20traverse%20and%20read%20the%20collapsed%20answer%20text%20even%20when%20%60aria-expanded%3D%22false%22%60%20on%20the%20trigger%20says%20it%20is%20closed.%20Adding%20%60hidden%60%20to%20the%20inner%20content%20%60div%60%20when%20the%20item%20is%20not%20open%20%E2%80%94%20and%20removing%20it%20during%20the%20open%20state%20%E2%80%94%20would%20hide%20the%20content%20from%20the%20accessibility%20tree%20while%20still%20allowing%20the%20grid-row%20CSS%20transition%20to%20animate%20%28the%20outer%20animated%20wrapper%20keeps%20its%20%60id%60%20and%20stays%20in%20the%20DOM%29.%0A%0A%23%23%23%20Issue%202%0Aweb%2Fsrc%2Fsections%2FFaq.tsx%3A138-142%0AFor%20full%20WAI-ARIA%20Accordion%20compliance%2C%20the%20panel%20should%20have%20%60role%3D%22region%22%60%20and%20%60aria-labelledby%60%20pointing%20back%20to%20its%20trigger%20button.%20This%20lets%20screen%20readers%20announce%20the%20section%20heading%20when%20navigating%20into%20the%20panel.%20This%20also%20requires%20adding%20an%20%60id%60%20to%20the%20button%20element.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3Cbutton%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20id%3D%7B%60faq-trigger-%24%7Bi%7D%60%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20type%3D%22button%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20aria-expanded%3D%7Bopen%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20aria-controls%3D%7BpanelId%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20style%3D%7B%7B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%0Aweb%2Fsrc%2Fsections%2FFaq.tsx%3A168-174%0APair%20the%20%60role%3D%22region%22%60%20and%20%60aria-labelledby%60%20on%20the%20panel%20wrapper%20to%20match%20the%20trigger%20button%20id%20added%20above.%20This%20completes%20the%20two-way%20association%20recommended%20by%20WAI-ARIA%20for%20accordion%20patterns.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3Cdiv%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20id%3D%7BpanelId%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20role%3D%22region%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20aria-labelledby%3D%7B%60faq-trigger-%24%7Bi%7D%60%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20style%3D%7B%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20display%3A%20%22grid%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20gridTemplateRows%3A%20open%20%3F%20%221fr%22%20%3A%20%220fr%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20transition%3A%20%22grid-template-rows%20.35s%20ease%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%7D%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=194&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/sections/Faq.tsx:168-175
**Collapsed content may still be read by screen readers**

The panel is always in the DOM and hidden only through a CSS grid trick (`gridTemplateRows: "0fr"` + `overflow: hidden`). This does not add `display: none`, `visibility: hidden`, or the HTML `hidden` attribute, so some screen readers (particularly VoiceOver and NVDA) may traverse and read the collapsed answer text even when `aria-expanded="false"` on the trigger says it is closed. Adding `hidden` to the inner content `div` when the item is not open — and removing it during the open state — would hide the content from the accessibility tree while still allowing the grid-row CSS transition to animate (the outer animated wrapper keeps its `id` and stays in the DOM).

### Issue 2
web/src/sections/Faq.tsx:138-142
For full WAI-ARIA Accordion compliance, the panel should have `role="region"` and `aria-labelledby` pointing back to its trigger button. This lets screen readers announce the section heading when navigating into the panel. This also requires adding an `id` to the button element.

```suggestion
                <button
                  id={`faq-trigger-${i}`}
                  type="button"
                  aria-expanded={open}
                  aria-controls={panelId}
                  style={{
```

### Issue 3
web/src/sections/Faq.tsx:168-174
Pair the `role="region"` and `aria-labelledby` on the panel wrapper to match the trigger button id added above. This completes the two-way association recommended by WAI-ARIA for accordion patterns.

```suggestion
                <div
                  id={panelId}
                  role="region"
                  aria-labelledby={`faq-trigger-${i}`}
                  style={{
                    display: "grid",
                    gridTemplateRows: open ? "1fr" : "0fr",
                    transition: "grid-template-rows .35s ease",
                  }}
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(a11y): connect FAQ triggers to panel..."](https://github.com/ishannaik/warp/commit/dd8b4997d79348814091d2dbcf8cd51d819d0304) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49973115)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->