### PR TITLE
docs(signaling): document ping, announce, and nearby frames

### DIFF
--- a/web/src/lib/warp/signaling.ts
+++ b/web/src/lib/warp/signaling.ts
@@ -1,5 +1,5 @@
 /**
- * Typed client for the Wrap signaling server.
+ * Typed client for the Warp signaling server.
  *
  * Transport: a single WebSocket to the live Cloudflare Worker. The server is a
  * dumb relay — it assigns a `selfId`, owns rooms, and forwards opaque `signal`
@@ -10,13 +10,19 @@
  *   { type: 'join' }                 create a fresh room, become its first peer
  *   { type: 'join', room: CODE }     join an existing room by code
  *   { type: 'signal', to, data }     relay an opaque payload to one peer
+ *   { type: 'ping' }                 keepalive so the Durable Object stays awake
+ *   { type: 'announce', ... }        LAN nearby discovery (not fully typed here)
  *
  * Protocol (server -> client):
  *   { type: 'joined', selfId, room, peers }   ack of our join (peers = existing)
  *   { type: 'peer-joined', peerId }           someone else joined our room
  *   { type: 'peer-left', peerId }             someone else left
  *   { type: 'signal', from, data }            a relayed payload from `from`
+ *   { type: 'nearby', devices | crowded }    same-network list (or overcrowded)
  *   { type: 'error', error }                  server-side failure
+ *
+ * Note: SignalingClient types the room/signal subset. Nearby discovery attaches
+ * a raw listener for announce/nearby frames (see useNearby.ts).
  */
 
 // Optional-chain `import.meta.env` so the module still loads outside Vite


### PR DESCRIPTION
## Summary
- Document `ping`, `announce`, and `nearby` in the `signaling.ts` protocol header (closes #186)
- Note that nearby still uses a raw listener; room/signal remain the typed subset
- Product name in module header: Wrap → Warp

## Test plan
- [ ] Header mentions ping / announce / nearby
- [ ] Docs-only; no runtime change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected terminology in the signaling client documentation.
  * Documented ping keepalives and LAN discovery messages.
  * Added details about the raw listener used for nearby device discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This is a docs-only PR that corrects the product name in the module header (`Wrap` → `Warp`) and expands the protocol reference table in `signaling.ts` to include `ping`/`announce` (client→server) and `nearby` (server→client), along with a note clarifying that `SignalingClient` only types the room/signal subset while nearby frames use a raw listener.

- Fixes the long-standing brand typo in the JSDoc module header.
- Adds `ping`, `announce`, and `nearby` to the protocol table, and documents that `useNearby.ts` handles those frames via a raw WebSocket listener rather than the typed `SignalingEvents` interface.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge — no runtime code changed; all modifications are JSDoc comments.

The change is entirely comment-level: a typo fix and additions to the protocol reference table. No logic, types, or runtime behaviour is touched. The two minor points are a formatting inconsistency in the `nearby` entry and the `CLAUDE.md` signaling section being left out of sync with the new frames.

**Files Needing Attention:** Only `web/src/lib/warp/signaling.ts` changed. `CLAUDE.md` (not in the diff) could also be updated to list `announce` and `nearby` for consistency.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/src/lib/warp/signaling.ts | Docs-only changes: fixes product name typo (Wrap→Warp), adds ping/announce to client→server protocol table, adds nearby to server→client table, and adds a note about the raw-listener pattern for nearby frames. Minor formatting inconsistency in the nearby entry's alignment and use of `|` vs `,`; CLAUDE.md's signaling section is not updated to include announce/nearby. |

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant C as Client
    participant S as Signaling Server (DO)

    C->>S: "{type: 'join'} / {type: 'join', room}"
    S-->>C: "{type: 'joined', selfId, room, peers[]}"

    loop Every 8s
        C->>S: "{type: 'ping'}"
    end

    C->>S: "{type: 'announce', ...}"
    S-->>C: "{type: 'nearby', devices | crowded}"

    C->>S: "{type: 'signal', to, data}"
    S-->>C: "{type: 'signal', from, data}"

    S-->>C: "{type: 'peer-joined', peerId}"
    S-->>C: "{type: 'peer-left', peerId}"
    S-->>C: "{type: 'error', error}"
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aweb%2Fsrc%2Flib%2Fwarp%2Fsignaling.ts%3A24%0A**CLAUDE.md%20signaling%20section%20not%20updated**%0A%0AThe%20%60CLAUDE.md%60%20%22Signaling%20protocol%22%20section%20still%20lists%20only%20the%20original%20four%20client%E2%86%92server%20frames%20%28%60join%60%2C%20%60join%2Broom%60%2C%20%60signal%60%2C%20%60ping%60%29%20and%20five%20server%E2%86%92client%20frames%20%E2%80%94%20%60announce%60%20and%20%60nearby%60%20are%20absent.%20Anyone%20using%20that%20file%20as%20the%20authoritative%20protocol%20reference%20%28CI%20checks%2C%20onboarding%29%20won't%20know%20about%20these%20two%20frames.%20Since%20CLAUDE.md%20is%20described%20as%20the%20team's%20canonical%20protocol%20gotchas%20guide%2C%20it%20should%20be%20kept%20in%20sync%20with%20the%20file-level%20comment%20updated%20here.%0A%0A%23%23%23%20Issue%202%0Aweb%2Fsrc%2Flib%2Fwarp%2Fsignaling.ts%3A21%0AThe%20%60nearby%60%20entry%20uses%20%60%7C%60%20where%20every%20other%20entry%20in%20this%20table%20uses%20%60%2C%60%20as%20a%20field%20separator%2C%20and%20its%20description%20is%20indented%20inconsistently%20%284%20spaces%20vs%20~12%20for%20the%20neighbouring%20lines%29.%20Splitting%20into%20two%20alternative%20forms%20makes%20the%20intent%20unambiguous%20and%20aligns%20with%20the%20existing%20table%20style.%0A%0A%60%60%60suggestion%0A%20*%20%20%20%7B%20type%3A%20'nearby'%2C%20devices%20%7D%20%20%20%20%20%20%20%20%20%20%20%20%20%20same-network%20device%20list%0A%20*%20%20%20%7B%20type%3A%20'nearby'%2C%20crowded%20%7D%20%20%20%20%20%20%20%20%20%20%20%20%20same-network%20request%20rejected%20%28too%20many%29%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ishannaik%2Fwarp&pr=195&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ishannaik%2Fwarp%22%20on%20the%20existing%20branch%20%22docs%2Fsignaling-nearby-ping-186%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22docs%2Fsignaling-nearby-ping-186%22.%0A%0A%23%23%23%20Issue%201%0Aweb%2Fsrc%2Flib%2Fwarp%2Fsignaling.ts%3A24%0A**CLAUDE.md%20signaling%20section%20not%20updated**%0A%0AThe%20%60CLAUDE.md%60%20%22Signaling%20protocol%22%20section%20still%20lists%20only%20the%20original%20four%20client%E2%86%92server%20frames%20%28%60join%60%2C%20%60join%2Broom%60%2C%20%60signal%60%2C%20%60ping%60%29%20and%20five%20server%E2%86%92client%20frames%20%E2%80%94%20%60announce%60%20and%20%60nearby%60%20are%20absent.%20Anyone%20using%20that%20file%20as%20the%20authoritative%20protocol%20reference%20%28CI%20checks%2C%20onboarding%29%20won't%20know%20about%20these%20two%20frames.%20Since%20CLAUDE.md%20is%20described%20as%20the%20team's%20canonical%20protocol%20gotchas%20guide%2C%20it%20should%20be%20kept%20in%20sync%20with%20the%20file-level%20comment%20updated%20here.%0A%0A%23%23%23%20Issue%202%0Aweb%2Fsrc%2Flib%2Fwarp%2Fsignaling.ts%3A21%0AThe%20%60nearby%60%20entry%20uses%20%60%7C%60%20where%20every%20other%20entry%20in%20this%20table%20uses%20%60%2C%60%20as%20a%20field%20separator%2C%20and%20its%20description%20is%20indented%20inconsistently%20%284%20spaces%20vs%20~12%20for%20the%20neighbouring%20lines%29.%20Splitting%20into%20two%20alternative%20forms%20makes%20the%20intent%20unambiguous%20and%20aligns%20with%20the%20existing%20table%20style.%0A%0A%60%60%60suggestion%0A%20*%20%20%20%7B%20type%3A%20'nearby'%2C%20devices%20%7D%20%20%20%20%20%20%20%20%20%20%20%20%20%20same-network%20device%20list%0A%20*%20%20%20%7B%20type%3A%20'nearby'%2C%20crowded%20%7D%20%20%20%20%20%20%20%20%20%20%20%20%20same-network%20request%20rejected%20%28too%20many%29%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ishannaik%2Fwarp&pr=195&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Aweb%2Fsrc%2Flib%2Fwarp%2Fsignaling.ts%3A24%0A**CLAUDE.md%20signaling%20section%20not%20updated**%0A%0AThe%20%60CLAUDE.md%60%20%22Signaling%20protocol%22%20section%20still%20lists%20only%20the%20original%20four%20client%E2%86%92server%20frames%20%28%60join%60%2C%20%60join%2Broom%60%2C%20%60signal%60%2C%20%60ping%60%29%20and%20five%20server%E2%86%92client%20frames%20%E2%80%94%20%60announce%60%20and%20%60nearby%60%20are%20absent.%20Anyone%20using%20that%20file%20as%20the%20authoritative%20protocol%20reference%20%28CI%20checks%2C%20onboarding%29%20won't%20know%20about%20these%20two%20frames.%20Since%20CLAUDE.md%20is%20described%20as%20the%20team's%20canonical%20protocol%20gotchas%20guide%2C%20it%20should%20be%20kept%20in%20sync%20with%20the%20file-level%20comment%20updated%20here.%0A%0A%23%23%23%20Issue%202%0Aweb%2Fsrc%2Flib%2Fwarp%2Fsignaling.ts%3A21%0AThe%20%60nearby%60%20entry%20uses%20%60%7C%60%20where%20every%20other%20entry%20in%20this%20table%20uses%20%60%2C%60%20as%20a%20field%20separator%2C%20and%20its%20description%20is%20indented%20inconsistently%20%284%20spaces%20vs%20~12%20for%20the%20neighbouring%20lines%29.%20Splitting%20into%20two%20alternative%20forms%20makes%20the%20intent%20unambiguous%20and%20aligns%20with%20the%20existing%20table%20style.%0A%0A%60%60%60suggestion%0A%20*%20%20%20%7B%20type%3A%20'nearby'%2C%20devices%20%7D%20%20%20%20%20%20%20%20%20%20%20%20%20%20same-network%20device%20list%0A%20*%20%20%20%7B%20type%3A%20'nearby'%2C%20crowded%20%7D%20%20%20%20%20%20%20%20%20%20%20%20%20same-network%20request%20rejected%20%28too%20many%29%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=195&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/lib/warp/signaling.ts:24
**CLAUDE.md signaling section not updated**

The `CLAUDE.md` "Signaling protocol" section still lists only the original four client→server frames (`join`, `join+room`, `signal`, `ping`) and five server→client frames — `announce` and `nearby` are absent. Anyone using that file as the authoritative protocol reference (CI checks, onboarding) won't know about these two frames. Since CLAUDE.md is described as the team's canonical protocol gotchas guide, it should be kept in sync with the file-level comment updated here.

### Issue 2
web/src/lib/warp/signaling.ts:21
The `nearby` entry uses `|` where every other entry in this table uses `,` as a field separator, and its description is indented inconsistently (4 spaces vs ~12 for the neighbouring lines). Splitting into two alternative forms makes the intent unambiguous and aligns with the existing table style.

```suggestion
 *   { type: 'nearby', devices }              same-network device list
 *   { type: 'nearby', crowded }             same-network request rejected (too many)
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(signaling): document ping, announce..."](https://github.com/ishannaik/warp/commit/46526ffd33976d756ec3918122bd51e4d07813cd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50295985)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->