### PR TITLE
fix(copy): plainer channel-error message for transfers

### DIFF
--- a/web/src/lib/warp/useWarpTransfer.ts
+++ b/web/src/lib/warp/useWarpTransfer.ts
@@ -195,7 +195,7 @@ const ERROR_MESSAGES: Record<WarpError["kind"], string> = {
   "nat-failed": "Couldn't open a direct path between the devices. One side may be on a restrictive network.",
   disconnected:
     "The connection dropped and couldn't be restored. Retry to reconnect — unfinished files will be offered again.",
-  "channel-error": "The direct link between the devices hit an error. Retry to reconnect.",
+  "channel-error": "The connection between the devices broke during the transfer. Hit retry to pair again.",
   signaling: "Lost contact with the signaling server.",
   "no-files": "Add at least one file before opening a channel.",
   "too-large": "This device can't receive a file this large. Try a desktop browser (Chrome/Edge).",

--- a/web/src/nearby/useNearbyTransfer.ts
+++ b/web/src/nearby/useNearbyTransfer.ts
@@ -83,7 +83,7 @@ export interface UseNearbyTransfer {
 const PEER_ERROR_COPY: Record<string, string> = {
   "nat-failed": "Couldn't open a direct channel. One device may be on a restrictive network.",
   disconnected: "The other device disconnected before the transfer finished.",
-  "channel-error": "The direct link to the other device broke.",
+  "channel-error": "The connection between the devices broke during the transfer. Hit retry to pair again.",
 };
 
 /** Trigger a browser download of a blob via a transient object-URL anchor. */


### PR DESCRIPTION
## Summary
- Replace technical "data channel hit an error" with actionable retry wording (closes #187)
- Same string in nearby transfer path for consistency

## Test plan
- [ ] Trigger channel-error path (or read ERROR_MESSAGES) shows new copy
- [ ] No behavior change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transfer error messages with clearer guidance for recovering from interrupted transfers.
  * Added specific instructions to retry pairing when a nearby transfer connection breaks.
  * Standardized error messaging across nearby and remote file transfers for a more consistent experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR replaces the technical `"The data channel hit an error."` string with a more user-friendly `"The connection between the devices broke during the transfer. Hit retry to pair again."` in both the warp and nearby transfer paths, and also fixes a previously hardcoded copy of that string at the `offerFiles` catch site in `useNearbyTransfer`.

- **`useWarpTransfer.ts`**: `ERROR_MESSAGES["channel-error"]` updated; the warp UI exposes a `retry()` function so "Hit retry" maps directly to a UI button.
- **`useNearbyTransfer.ts`**: `PEER_ERROR_COPY["channel-error"]` updated and the inline `failSession` at line 232 now references the constant (fixing the stale-string issue from the previous review). However, the nearby `SessionError` component renders only a "Close" button — there is no `retry()` in `UseNearbyTransfer` — so "Hit retry to pair again" does not correspond to any available control in that flow.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge after addressing the copy mismatch in the nearby error path.

The warp side is clean — `retry()` exists and the message matches. The nearby side fixes the stale hardcoded string but the new "Hit retry" call-to-action has no backing button: `SessionError` renders only "Close", and `UseNearbyTransfer` exposes no retry action. Users on the nearby channel-error path will be told to do something the UI doesn't offer.

**Files Needing Attention:** web/src/nearby/useNearbyTransfer.ts — the `"channel-error"` copy needs a nearby-specific call-to-action, or the `SessionError` component needs a retry path.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/src/lib/warp/useWarpTransfer.ts | Updates ERROR_MESSAGES["channel-error"] to actionable user copy; change is straightforward and the warp UI exposes a retry() function that matches the new "Hit retry" call-to-action. |
| web/src/nearby/useNearbyTransfer.ts | Updates PEER_ERROR_COPY["channel-error"] and fixes the previously hardcoded inline string at line 232, but the new copy says "Hit retry to pair again" while the nearby error UI (SessionError) renders only a "Close" button — no retry action exists in UseNearbyTransfer. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[channel-error event] --> B{Which transfer path?}
    B --> C[useWarpTransfer]
    B --> D[useNearbyTransfer]

    C --> C1["ERROR_MESSAGES updated"]
    C1 --> C2["UI shows Retry button, retry() exists"]

    D --> D1["PEER_ERROR_COPY updated"]
    D --> D2["offerFiles catch now uses PEER_ERROR_COPY"]
    D1 --> D3["SessionError renders Close button only"]
    D2 --> D3
    D3 --> D4["Message says Hit retry but no retry action exists"]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aweb%2Fsrc%2Fnearby%2FuseNearbyTransfer.ts%3A82%0A**%22Hit%20retry%22%20instruction%20has%20no%20matching%20button%20in%20nearby%20UI**%0A%0AThe%20new%20%60%22channel-error%22%60%20copy%20tells%20users%20to%20%22Hit%20retry%20to%20pair%20again%22%2C%20but%20%60SessionError%60%20in%20%60NearbyDevices.tsx%60%20%28line%20572%29%20renders%20only%20a%20**%22Close%22**%20button%20backed%20by%20%60dismissSession%60.%20There%20is%20no%20retry%20action%20in%20%60UseNearbyTransfer%60.%20A%20user%20who%20hits%20the%20channel-error%20path%20on%20the%20nearby%20flow%20will%20read%20%22Hit%20retry%22%20and%20find%20nothing%20to%20tap%20%E2%80%94%20the%20only%20affordance%20closes%20the%20session%20and%20drops%20them%20back%20to%20the%20device%20list.%0A%0AThe%20warp%20path%20does%20have%20a%20%60retry%28%29%60%20function%2C%20so%20the%20same%20string%20is%20accurate%20there.%20The%20nearby%20copy%20needs%20its%20own%20call-to-action%2C%20e.g.%20%60%22The%20connection%20between%20the%20devices%20broke%20during%20the%20transfer.%20Close%20and%20tap%20the%20device%20to%20pair%20again.%22%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ishannaik%2Fwarp&pr=196&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ishannaik%2Fwarp%22%20on%20the%20existing%20branch%20%22fix%2Fchannel-error-copy-187%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fchannel-error-copy-187%22.%0A%0A%23%23%23%20Issue%201%0Aweb%2Fsrc%2Fnearby%2FuseNearbyTransfer.ts%3A82%0A**%22Hit%20retry%22%20instruction%20has%20no%20matching%20button%20in%20nearby%20UI**%0A%0AThe%20new%20%60%22channel-error%22%60%20copy%20tells%20users%20to%20%22Hit%20retry%20to%20pair%20again%22%2C%20but%20%60SessionError%60%20in%20%60NearbyDevices.tsx%60%20%28line%20572%29%20renders%20only%20a%20**%22Close%22**%20button%20backed%20by%20%60dismissSession%60.%20There%20is%20no%20retry%20action%20in%20%60UseNearbyTransfer%60.%20A%20user%20who%20hits%20the%20channel-error%20path%20on%20the%20nearby%20flow%20will%20read%20%22Hit%20retry%22%20and%20find%20nothing%20to%20tap%20%E2%80%94%20the%20only%20affordance%20closes%20the%20session%20and%20drops%20them%20back%20to%20the%20device%20list.%0A%0AThe%20warp%20path%20does%20have%20a%20%60retry%28%29%60%20function%2C%20so%20the%20same%20string%20is%20accurate%20there.%20The%20nearby%20copy%20needs%20its%20own%20call-to-action%2C%20e.g.%20%60%22The%20connection%20between%20the%20devices%20broke%20during%20the%20transfer.%20Close%20and%20tap%20the%20device%20to%20pair%20again.%22%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ishannaik%2Fwarp&pr=196&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Aweb%2Fsrc%2Fnearby%2FuseNearbyTransfer.ts%3A82%0A**%22Hit%20retry%22%20instruction%20has%20no%20matching%20button%20in%20nearby%20UI**%0A%0AThe%20new%20%60%22channel-error%22%60%20copy%20tells%20users%20to%20%22Hit%20retry%20to%20pair%20again%22%2C%20but%20%60SessionError%60%20in%20%60NearbyDevices.tsx%60%20%28line%20572%29%20renders%20only%20a%20**%22Close%22**%20button%20backed%20by%20%60dismissSession%60.%20There%20is%20no%20retry%20action%20in%20%60UseNearbyTransfer%60.%20A%20user%20who%20hits%20the%20channel-error%20path%20on%20the%20nearby%20flow%20will%20read%20%22Hit%20retry%22%20and%20find%20nothing%20to%20tap%20%E2%80%94%20the%20only%20affordance%20closes%20the%20session%20and%20drops%20them%20back%20to%20the%20device%20list.%0A%0AThe%20warp%20path%20does%20have%20a%20%60retry%28%29%60%20function%2C%20so%20the%20same%20string%20is%20accurate%20there.%20The%20nearby%20copy%20needs%20its%20own%20call-to-action%2C%20e.g.%20%60%22The%20connection%20between%20the%20devices%20broke%20during%20the%20transfer.%20Close%20and%20tap%20the%20device%20to%20pair%20again.%22%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=196&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/nearby/useNearbyTransfer.ts:82
**"Hit retry" instruction has no matching button in nearby UI**

The new `"channel-error"` copy tells users to "Hit retry to pair again", but `SessionError` in `NearbyDevices.tsx` (line 572) renders only a **"Close"** button backed by `dismissSession`. There is no retry action in `UseNearbyTransfer`. A user who hits the channel-error path on the nearby flow will read "Hit retry" and find nothing to tap — the only affordance closes the session and drops them back to the device list.

The warp path does have a `retry()` function, so the same string is accurate there. The nearby copy needs its own call-to-action, e.g. `"The connection between the devices broke during the transfer. Close and tap the device to pair again."`

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(copy): nearby offer path uses PEER\_E..."](https://github.com/ishannaik/warp/commit/41a54d61153579eae3f42803af545381e571e106) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50296210)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->