### PR TITLE
copy: signaling fallback card (drop RELAY FALLBACK)

### DIFF
--- a/web/src/sections/Architecture.tsx
+++ b/web/src/sections/Architecture.tsx
@@ -323,10 +323,10 @@ export default function Architecture() {
             </p>
           </div>
           <div style={cardBase}>
-            <div style={cardLabel}>RELAY FALLBACK</div>
+            <div style={cardLabel}>SIGNALING FALLBACK</div>
             <p style={cardBody}>
-              If a direct path can&rsquo;t form, an encrypted relay finishes the
-              job &mdash; still unreadable to us.
+              If a direct path can&rsquo;t form, signaling helps peers reconnect
+              without holding your file data &mdash; still unreadable to us.
             </p>
           </div>
         </div>

--- a/web/src/sections/Architecture.tsx
+++ b/web/src/sections/Architecture.tsx
@@ -325,8 +325,8 @@ export default function Architecture() {
           <div style={cardBase}>
             <div style={cardLabel}>SIGNALING FALLBACK</div>
             <p style={cardBody}>
-              If a direct path can&rsquo;t form, signaling helps peers reconnect
-              without holding your file data &mdash; still unreadable to us.
+              If the connection drops, signaling helps peers reconnect without
+              holding your file data &mdash; still unreadable to us.
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Architecture marketing card: RELAY FALLBACK → SIGNALING FALLBACK (closes #173)
- Copy clarifies signaling helps reconnect without holding file data

## Test plan
- [ ] Architecture section shows SIGNALING FALLBACK
- [ ] No product behavior change

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR renames the architecture marketing card from "RELAY FALLBACK" to "SIGNALING FALLBACK" and rewrites its body copy to accurately reflect that Warp is a STUN-only app with no TURN relay. The old copy implied an encrypted relay was used when P2P failed, which contradicted the actual behavior described in CLAUDE.md.

- **Label change**: "RELAY FALLBACK" → "SIGNALING FALLBACK" removes the misleading suggestion that a relay takes over when a direct path can't form.
- **Body copy**: Scopes the reconnection behavior to transient drops ("if the connection drops"), which aligns with how ICE restarts and signaling auto-rejoin actually work, and explicitly notes the signaling server never holds file data.
</details>

<h3>Confidence Score: 5/5</h3>

This is a copy-only change with no logic, state, or behavior modifications — safe to merge.

The change touches a single marketing card in the Architecture section, replacing technically inaccurate relay copy with accurate signaling-based reconnection copy that matches what the app actually does per CLAUDE.md. No code paths are affected.

**Files Needing Attention:** No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/src/sections/Architecture.tsx | Copy-only change: updates the architecture card label and body to accurately describe signaling-based reconnection instead of a relay fallback. No logic or structural changes. |

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Sender
    participant Signaling as Signaling Server (dumb relay)
    participant Receiver

    Sender->>Signaling: join (no room)
    Signaling-->>Sender: "joined {selfId, room}"
    Receiver->>Signaling: "join {room}"
    Signaling-->>Receiver: joined
    Signaling-->>Sender: peer-joined

    Note over Sender,Receiver: WebRTC ICE negotiation via signaling
    Sender->>Signaling: "signal {to, offer/candidates}"
    Signaling->>Receiver: "signal {from, offer/candidates}"
    Receiver->>Signaling: "signal {to, answer/candidates}"
    Signaling->>Sender: "signal {from, answer/candidates}"

    Note over Sender,Receiver: P2P data channel open — file bytes never touch signaling

    Note over Sender,Receiver: Transient drop detected
    Sender->>Signaling: reconnect + rejoin
    Receiver->>Signaling: reconnect + rejoin
    Note over Sender,Receiver: ICE restart via signaling → P2P resumes
    Note over Sender,Receiver: Permanent NAT failure → honest error shown to user
```
</details>

<sub>Reviews (2): Last reviewed commit: ["copy: clarify signaling reconnects after..."](https://github.com/ishannaik/warp/commit/a537b0de6cfd423844aa5726f0c0e36b759f5b89) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50296249)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/ishannaik/github/Ishannaik/warp/-/custom-context?memory=575c40ec-32b8-4814-a2b7-1ced5808ec85))

<!-- /greptile_comment -->