### PR TITLE
docs(threat-model): derive room-code entropy from source

### DIFF
--- a/docs/THREAT-MODEL.md
+++ b/docs/THREAT-MODEL.md
@@ -33,7 +33,110 @@ For additional background on the networking model, see [theory-content.md](./the
 
 ## Room Code Entropy
 
-(To be documented.)
+The room code is the system's front-door secret: it is what stands between an outsider and being treated as a legitimate peer in someone else's room, so its resistance to guessing is the whole story for room access. It is not the system's only secret. The sender also mints a per-file `resumeToken` (`newResumeToken()`, `web/src/lib/warp/transfer.ts:180`), which authorizes resuming an already-accepted transfer so that a device already inside a mesh room cannot hijack a partial file (`docs/ARCHITECTURE.md:182`, `:184`). That token guards resumption, not entry, and its own strength is out of scope here. This section does the room-code arithmetic from the source and states the result plainly.
+
+### The alphabet and the code
+
+`server/src/index.js:7-8` defines both halves:
+
+```js
+const CODE_ALPHABET = 'ABCDEFGHJKMNPQRSTUVWXYZ23456789';   // no ambiguous 0/O/1/I/L
+const CODE_LEN = 6;
+```
+
+The alphabet is **31 symbols**: 23 letters (A-Z minus `I`, `L` and `O`) plus 8 digits (`2`-`9`). The excluded characters are the ones that read alike when a code is spoken aloud or copied off a screen, so the exclusions buy usability and cost entropy. The server's authoritative `ROOM_RE` is built from those same two constants (`server/src/index.js:9`), and `web/src/lib/warp/roomCode.ts:10` mirrors the set client-side as `/^[A-HJ-KM-NP-Z2-9]{6}$/` for fast format checks only.
+
+Six independent characters drawn from 31 symbols gives:
+
+- Combinations: `31^6 = 887,503,681`
+- Bits: `log2(31^6) = 6 * log2(31) = 6 * 4.9542 = 29.7252`
+
+A Warp room code therefore carries about **29.7 bits** of entropy. State that plainly: 29.7 bits is not a strong secret. It is a rendezvous token that has to survive being read aloud over a phone call, and it should be judged against how long a room stays open, not against a password or a key.
+
+### Where the bits come from, and the modulo bias
+
+`makeCode()` (`server/src/index.js:61-69`) draws six bytes from the platform CSPRNG and folds each one into the alphabet:
+
+```js
+const bytes = crypto.getRandomValues(new Uint8Array(CODE_LEN));
+code = '';
+for (let i = 0; i < CODE_LEN; i++) code += CODE_ALPHABET[bytes[i] % CODE_ALPHABET.length];
+```
+
+`crypto.getRandomValues` is the correct source, and the `do...while (this.roomExists(code))` loop at `:63-67` only rerolls on a collision with a live room, so it does not narrow the space in any attacker-useful way.
+
+The reduction on line 66 is where a small flaw enters. A byte holds 256 values and 256 is not a multiple of 31:
+
+```
+256 = 8 * 31 + 8
+```
+
+Those eight leftover values fall on the first eight symbols of the alphabet, making `A` through `H` slightly more likely than the other 23:
+
+| Symbols | Byte values mapping to it | Probability per character |
+| --- | --- | --- |
+| `ABCDEFGH` (8 symbols) | 9 | `9/256` = 3.5156% |
+| `JKMNPQRSTUVWXYZ23456789` (23 symbols) | 8 | `8/256` = 3.1250% |
+| uniform, for reference | - | `1/31` = 3.2258% |
+
+An `A` is 1.125 times as likely as a `J`.
+
+**Does the bias matter at this bit count? No.** Shannon entropy under that skew is 4.95221 bits per character against 4.95420 for a uniform draw, so a code lands at **29.7133 bits instead of 29.7252**, a loss of about **0.012 bits** across the whole code. For an attacker ordering guesses by likelihood, the single most probable code (all six characters drawn from `A`-`H`) is only 1.68 times more likely than any code under a uniform draw. Stated as min-entropy, the strict worst case an attacker can aim at, that is 28.98 bits against the 29.73-bit uniform figure: an advantage of about 0.75 bits. Rejection sampling (redraw when a byte lands in the ragged tail above 247) would remove the bias cleanly, and it would change the practical security of the code by roughly nothing. The bias is worth knowing about and worth fixing on style grounds. It is not what makes a 6-character code weak.
+
+### What a brute-force attempt looks like
+
+Guessing a code is an **online attack against the signaling server**. There is no offline component: no hash to crack, no token to grind at local CPU speed. Every guess costs one `join` message on a WebSocket (`server/src/index.js:83`, handled at `:89`), and the reply tells the attacker exactly what happened:
+
+| Reply | Meaning | Source |
+| --- | --- | --- |
+| `bad-room` | Malformed code, did not match `ROOM_RE` | `:96-97` |
+| `room-not-found` | Well-formed, but no live room and no unexpired reservation | `:98`, `:105-108` |
+| `room-full` | **Correct code**, but the room already holds `MAX_PEERS` (8) | `:110-111`, `:5` |
+| `joined` | **Correct code**, and the sender is now a peer in the mesh | `:119-120` |
+
+Two properties make this cheap for an attacker:
+
+1. **Every guess gets an unambiguous answer.** There is no generic failure. `room-full` even confirms a hit on a room the attacker cannot enter.
+2. **A failed guess costs nothing.** The error paths return without closing the socket and without clearing the socket's attachment, and `webSocketMessage` (`server/src/index.js:76-87`) keeps no attempt counter, no backoff, and no per-IP accounting. One connection can carry an unbounded run of guesses.
+
+The number that actually governs risk is not 887,503,681. An attacker is not searching for one fixed secret; they are searching for **any room that happens to be open right now**. With `n` rooms live concurrently, each guess succeeds with probability `n / 887,503,681`, and the expected work drops in direct proportion to how busy the service is:
+
+| Live rooms | Probability per guess | Guesses for a 50% chance of one hit |
+| --- | --- | --- |
+| 1 | 1.13e-9 | ~615,000,000 |
+| 10 | 1.13e-8 | ~61,500,000 |
+| 100 | 1.13e-7 | ~6,150,000 |
+| 1,000 | 1.13e-6 | ~615,000 |
+
+Sweeping the full space at 100 guesses per second takes about 103 days, so a single low-traffic room is not realistically brute-forced. The exposure grows with adoption, not with time.
+
+The two caps in the file are not defenses against this. `MAX_PEERS = 8` (`:5`) bounds mesh size per room, and `MAX_DISCOVER = 8` (`:6`) is a privacy guardrail on nearby-device listing. Neither one limits how many codes a client may try.
+
+### The reclaim window widens the target
+
+`RECLAIM_MS = 3 * 60 * 1000` (`server/src/index.js:10`) reserves a code for **three minutes** after its last socket drops. `handleGone()` writes a `reclaim:<code>` record when the room empties (`:190-193`), and `handleJoin()` checks that record before answering `room-not-found` (`:105-108`).
+
+This exists so two devices that drop together, on a shared tunnel or train Wi-Fi, can rejoin the same rendezvous point and resume. It also means a code stays guessable for three minutes after everyone has left it. Two consequences follow:
+
+- A code's guessable lifetime is its live session plus three minutes, so every room contributes more exposure than its actual use.
+- The first reclaim-join wins and deletes the record (`:109`). An attacker who guesses a code inside that window occupies the rendezvous point before the legitimate peers return, which denies them the reclaim they were relying on.
+
+The record is best-effort GC'd by an alarm (`:203-209`), and reads re-validate expiry, so the three-minute bound holds even when the alarm is delayed. No transfer state is restored on reclaim; the server only owes the same code back.
+
+What a successful guess gets an attacker, and what a peer inside a room can then do, belongs to the Malicious Peer section above.
+
+### What throttles guessing today
+
+**Nothing in this repository.** There is no per-IP join limit, no per-connection attempt cap, and no backoff on repeated `room-not-found` replies anywhere in `server/src/index.js`. The signaling server accepts guesses as fast as a client can send them, bounded only by the hosting platform's general service protections, which are not a control tuned for this.
+
+[Issue #31](https://github.com/Ishannaik/warp/issues/31), "Rate-limit join attempts per IP in the signaling Durable Object", tracks the fix. It is **open and unmerged as of this writing**, so it is a known gap, not a shipped mitigation. Reading this doc and expecting rate limiting to be in place would be wrong.
+
+Given that, the honest summary of the room code's strength is:
+
+- 29.7 bits, minus a rounding error of bias, against an online-only attacker.
+- Adequate for a short-lived rendezvous between two people who already trust each other.
+- Not adequate as a durable secret, not a substitute for verifying who joined, and weaker in aggregate the more rooms are open at once.
+- Improved most by rate limiting the guesses (#31), not by growing the alphabet.
 
 ## Client-side Attack Surface
 

--- a/docs/THREAT-MODEL.md
+++ b/docs/THREAT-MODEL.md
@@ -67,7 +67,7 @@ for (let i = 0; i < CODE_LEN; i++) code += CODE_ALPHABET[bytes[i] % CODE_ALPHABE
 
 The reduction on line 66 is where a small flaw enters. A byte holds 256 values and 256 is not a multiple of 31:
 
-```
+```text
 256 = 8 * 31 + 8
 ```
 
@@ -108,7 +108,7 @@ The number that actually governs risk is not 887,503,681. An attacker is not sea
 | 100 | 1.13e-7 | ~6,150,000 |
 | 1,000 | 1.13e-6 | ~615,000 |
 
-Sweeping the full space at 100 guesses per second takes about 103 days, so a single low-traffic room is not realistically brute-forced. The exposure grows with adoption, not with time.
+At 100 guesses per second, sweeping the full space takes about 103 days, and the 50% mark against one live room arrives at about 71 days (615,000,000 / 100 = 6,150,000 seconds). Neither figure describes a real attack, because no room survives long enough to absorb it: a code is guessable only for its live session plus the three-minute reclaim window below. What an attacker actually accumulates is guesses against whatever set of rooms happens to be open while they are guessing, so exposure grows with concurrent rooms, room lifetime, and attacker guess rate.
 
 The two caps in the file are not defenses against this. `MAX_PEERS = 8` (`:5`) bounds mesh size per room, and `MAX_DISCOVER = 8` (`:6`) is a privacy guardrail on nearby-device listing. Neither one limits how many codes a client may try.
 
@@ -119,7 +119,7 @@ The two caps in the file are not defenses against this. `MAX_PEERS = 8` (`:5`) b
 This exists so two devices that drop together, on a shared tunnel or train Wi-Fi, can rejoin the same rendezvous point and resume. It also means a code stays guessable for three minutes after everyone has left it. Two consequences follow:
 
 - A code's guessable lifetime is its live session plus three minutes, so every room contributes more exposure than its actual use.
-- The first reclaim-join wins and deletes the record (`:109`). An attacker who guesses a code inside that window occupies the rendezvous point before the legitimate peers return, which denies them the reclaim they were relying on.
+- The first reclaim-join wins and deletes the record (`:109`), and the same join turns the code back into a live room. An attacker who guesses a code inside that window gains unauthorized membership of the rendezvous point the legitimate peers were returning to. Those peers are not locked out by that alone — they still reach the room by the ordinary live-room path (`:98`, `:110-111`, `:119`) and find the attacker already inside. Denying them the rendezvous takes a further act: filling the room to `MAX_PEERS` (8) or otherwise disrupting it.
 
 The record is best-effort GC'd by an alarm (`:203-209`), and reads re-validate expiry, so the three-minute bound holds even when the alarm is delayed. No transfer state is restored on reclaim; the server only owes the same code back.
 


### PR DESCRIPTION
## What & why

Fills the `## Room Code Entropy` placeholder in `docs/THREAT-MODEL.md`. Every number is derived from the signaling server as it stands today rather than restated from memory:

- **31-symbol alphabet, 6-character code** (`server/src/index.js:7-8`) → `31^6 = 887,503,681`, about **29.73 bits**. Stated plainly as "not a strong secret" — it's a rendezvous token, not a key.
- **Modulo bias.** `bytes[i] % 31` over a 0–255 byte (`:66`) gives `A`–`H` 9/256 and the other 23 symbols 8/256, a 1.125 ratio. That costs **0.012 bits** of Shannon entropy (0.74 bits of min-entropy). Worth fixing on style grounds; explicitly *not* what makes a 6-character code weak. The section says so rather than leaving a reader to over-weight it.
- **Brute force is online-only.** One `join` per guess (`:83`, handled at `:89`), every reply an unambiguous answer (`bad-room` / `room-not-found` / `room-full` / `joined`), and `webSocketMessage` (`:76-87`) keeps no attempt counter, no backoff, no per-IP accounting. The governing number isn't 887M against one fixed code — with `n` rooms live, each guess hits with probability `n / 887,503,681`, so exposure grows with adoption.
- **The reclaim window.** `RECLAIM_MS` (`:10`) keeps a code guessable for three minutes past its last socket, and first-reclaim-wins (`:109`) means a correct guess inside that window takes the rendezvous point.
- **What throttles guessing today: nothing in this repo.** Names #31 as an *open, unmerged* gap rather than implying a shipped mitigation.

It also notes that the room code is the front-door secret but not the only one — the per-file `resumeToken` (`transfer.ts:180`) authorizes resumption, not entry — so the section isn't read as a claim about the whole system.

Docs only: one file, +104/-1, and the deleted line is the `(To be documented.)` placeholder.

Closes #159

## Type

- [ ] feat
- [ ] fix
- [x] docs / chore / refactor / test / perf

## Checklist

- [x] Re-verified against the current tip of `main`: every cited line anchor still resolves and `server/src/index.js`, `roomCode.ts`, `transfer.ts` and `ARCHITECTURE.md` are byte-identical to the revision the numbers were derived from.
- [x] Arithmetic recomputed independently (combinations, uniform bits, the 9/256–8/256 split, Shannon and min-entropy, the per-room hit probabilities, the 103-day full-sweep figure).
- [x] Both embedded code snippets diffed verbatim against source.
- [x] #31 confirmed still open, so the "not a shipped mitigation" wording is accurate.

Not run: `pnpm lint` / `typecheck` / `build`. The diff touches zero code and CI's paths filter scopes those jobs to `web/` and `server/`, so they don't apply to this change — flagging it rather than checking a box I didn't earn.

No UI, no screenshots.

### Hard constraints

- [x] No new recurring-cost infrastructure
- [x] Still STUN-only
- [x] The signaling server still never reads, stores, or understands file contents
- [x] `SEND_HIGH_WATER` untouched
- [x] Transient network drops still recover

All five hold trivially — this PR changes one Markdown file.

## Notes for review

Two judgement calls worth a second opinion:

1. The section reframes the risk from "887M combinations" to "expected work scales with how many rooms are open right now". I think that's the honest framing for a rendezvous code, but it's a stronger claim than a raw entropy count and I'd rather you agree with it than inherit it.
2. It says the bias is not worth alarm. If you'd prefer the doc simply recommend rejection sampling without the "changes practical security by roughly nothing" line, that's a one-paragraph edit.

Separately, and deliberately out of scope for this PR: `newResumeToken()` (`transfer.ts:180`) builds its token from `Math.random()` while its docstring calls it unguessable. That's a different threat from room-code entropy — happy to open it as its own issue if it isn't already known.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added detailed security documentation covering room-code generation, entropy, and modulo bias.
  * Documented brute-force, concurrent-room, reclaim-window, and rate-limiting considerations.
  * Clarified the distinction between room-entry codes and file resume tokens.
  * Replaced placeholder content with a comprehensive threat-model section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR replaces the room-code entropy placeholder with source-derived documentation of code generation, modulo bias, online guessing exposure, reclaim behavior, and the absence of repository-level rate limiting.
- Calculates the effective entropy of six-character room codes.
- Explains concurrent-room and online brute-force risk.
- Correctly clarifies that reclaiming a code grants unauthorized membership but does not itself exclude legitimate peers.
- Distinguishes room entry from resume-token authorization.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the revised reclaim discussion matches the current server join behavior.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/THREAT-MODEL.md | Adds a detailed room-code threat analysis and correctly resolves the prior overstatement about reclaim joins denying legitimate peers. |

<sub>Reviews (2): Last reviewed commit: ["docs(threat-model): address review on en..."](https://github.com/ishannaik/warp/commit/851c477e8e7e4c27d1d51e5e03e7fd30fba4af93) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50754755)</sub>

<!-- /greptile_comment -->