### PR TITLE
test(transfer): cover textSnippetFrameBytes in transfer.check.mjs

### DIFF
--- a/web/src/lib/warp/transfer.check.mjs
+++ b/web/src/lib/warp/transfer.check.mjs
@@ -29,7 +29,8 @@ try {
   process.exit(0);
 }
 
-const { fileKey, newResumeToken, formatBytes } = mod;
+const { fileKey, newResumeToken, formatBytes, textSnippetFrameBytes, TEXT_SNIPPET_MAX_BYTES, fileId } =
+  mod;
 
 // --- fileKey: stable per (name,size,mtime); changes when any of them changes ---
 const a = { name: "clip.mp4", size: 1234, lastModified: 42 };
@@ -60,4 +61,77 @@ assert.equal(formatBytes(120_000_000), "120 MB", "large MB uses zero decimals");
 assert.equal(formatBytes(999_999_999), "1.0 GB", "999_999_999 must not render as 1000 MB");
 assert.equal(formatBytes(1_000_000_000), "1.0 GB", "exact GB boundary");
 
-console.log("OK: transfer.ts resume identity helpers (fileKey stability + token uniqueness) + formatBytes boundaries");
+// --- textSnippetFrameBytes: measures the wire frame, not the string ---
+// The value guards `SessionView`'s composer hint and `peer.ts`'s send-side throw, so it has
+// to count what is actually JSON-encoded: the envelope, and UTF-8 bytes rather than UTF-16
+// code units.
+const utf8 = (s) => new TextEncoder().encode(s).byteLength;
+
+// The empty frame is pure envelope: {"t":"text","id":"xxxxxxxx","text":""}
+const ENVELOPE_BYTES = textSnippetFrameBytes("");
+assert.equal(ENVELOPE_BYTES, 38, "empty snippet still costs the JSON envelope");
+
+for (const [label, text] of [
+  ["empty", ""],
+  ["ascii", "hello world"],
+  ["multi-byte", "👋 héllo — ünïcode"],
+  ["astral only", "👋🏽👨‍👩‍👧‍👦"],
+]) {
+  assert.ok(
+    textSnippetFrameBytes(text) >= utf8(text),
+    `${label}: frame is never smaller than the raw UTF-8 payload`,
+  );
+  assert.equal(
+    textSnippetFrameBytes(text),
+    ENVELOPE_BYTES + utf8(text),
+    `${label}: frame is exactly envelope + UTF-8 payload when nothing needs escaping`,
+  );
+}
+
+// The whole reason the helper exists: `.length` under-counts multi-byte text.
+// "👋" is 2 UTF-16 code units but 4 UTF-8 bytes, so a naive check leaks 2 bytes per emoji.
+assert.ok(
+  textSnippetFrameBytes("👋") - ENVELOPE_BYTES > "👋".length,
+  "multi-byte text costs more bytes than String#length suggests",
+);
+
+// JSON escaping expands on the wire too: `"` and `\` each serialize to two bytes.
+assert.equal(textSnippetFrameBytes('"'), ENVELOPE_BYTES + 2, 'a quote is escaped to \\" on the wire');
+assert.equal(textSnippetFrameBytes("\\"), ENVELOPE_BYTES + 2, "a backslash is escaped to \\\\ on the wire");
+assert.ok(
+  textSnippetFrameBytes('""""') > utf8('""""'),
+  "escaping is counted, so quote-heavy text is larger than its raw byte length",
+);
+
+// --- textSnippetFrameBytes: the cap boundary peer.ts throws on ---
+const atCap = "a".repeat(TEXT_SNIPPET_MAX_BYTES - ENVELOPE_BYTES);
+assert.equal(textSnippetFrameBytes(atCap), TEXT_SNIPPET_MAX_BYTES, "largest exact-fit snippet lands on the cap");
+assert.ok(textSnippetFrameBytes(atCap) <= TEXT_SNIPPET_MAX_BYTES, "an exact-fit snippet is accepted");
+assert.ok(
+  textSnippetFrameBytes(atCap + "a") > TEXT_SNIPPET_MAX_BYTES,
+  "one byte past the cap is rejected — the boundary is not off by one",
+);
+assert.ok(
+  textSnippetFrameBytes("x".repeat(TEXT_SNIPPET_MAX_BYTES)) > TEXT_SNIPPET_MAX_BYTES,
+  "a clearly oversized snippet exceeds the cap",
+);
+
+// --- textSnippetFrameBytes: the default probe id must bound every real id ---
+// `SessionView` measures with the default probe id before an id exists, while `peer.ts`
+// measures with the real one from `fileId()`. The UI hint is only safe if the probe is
+// never shorter than a real id, otherwise a snippet could pass the hint and throw on send.
+const PROBE_ID_BYTES = 8;
+for (let i = 0; i < 200; i++) {
+  assert.ok(
+    utf8(fileId()) <= PROBE_ID_BYTES,
+    "fileId() never exceeds the default probe id, so the composer hint stays conservative",
+  );
+}
+assert.ok(
+  textSnippetFrameBytes("hi", "short") <= textSnippetFrameBytes("hi"),
+  "a shorter id yields a smaller frame than the probe id estimate",
+);
+
+console.log(
+  "OK: transfer.ts resume identity helpers (fileKey stability + token uniqueness) + formatBytes boundaries + textSnippetFrameBytes envelope/UTF-8/escaping/cap",
+);


### PR DESCRIPTION
## What & why

`transfer.check.mjs` covered `fileKey`, `newResumeToken` and `formatBytes`, so
`textSnippetFrameBytes` — the one helper the composer hint in `SessionView.tsx` and the
send-side throw in `peer.ts:632` both read — had no coverage in the pure-module harness.

Test-only. Adds asserts for the four ways that byte count can drift:

- **Envelope.** The empty frame costs 38 bytes, and every frame is exactly
  `envelope + UTF-8 payload` when nothing needs escaping. Envelope drift shows up here first.
- **UTF-8 vs UTF-16.** The helper exists because `.length` under-counts multi-byte text, so
  that is asserted head-on: `👋` is 2 code units but 4 bytes.
- **JSON escaping.** `"` and `\` each serialize to two bytes, so quote-heavy text is larger
  than its raw byte length.
- **The cap boundary.** An exact-fit snippet lands on `TEXT_SNIPPET_MAX_BYTES` and one byte
  more exceeds it — the boundary `peer.ts` throws on is not off by one.

It also pins the invariant that makes the UI hint safe: `SessionView` measures with the
default probe id before a real id exists, so `fileId()` must never produce more than those
8 bytes. If it could, a snippet would pass the hint and then throw on send.

Per the acceptance criteria I went looking for a real bug and did not find one:
`fileId()` is `Math.random().toString(36).slice(2, 10)`, which is at most 8 characters, so
the probe id is a conservative upper bound and the hint is correctly on the safe side.
`transfer.ts` is byte-identical to `main`.

Closes #188

## Type

- [ ] feat
- [ ] fix
- [x] docs / chore / refactor / test / perf

## Checklist

- [x] `pnpm lint && pnpm typecheck` pass locally
- [x] `pnpm --filter @warp/web build` is green (web changes)
- [x] Engine changes: the relevant `web/src/lib/warp/*.check.mjs` harness passes (and covers the new behaviour)

Not applicable and deliberately dropped: server tests (no server change), the mobile-width
check and the design-token line (no UI change).

### Hard constraints

- [x] No new recurring-cost infrastructure
- [x] Still STUN-only
- [x] The signaling server still never reads, stores, or understands file contents
- [x] `SEND_HIGH_WATER` in `peer.ts` untouched
- [x] Transient network drops still recover

## What I tested

```
node src/lib/warp/transfer.check.mjs   OK
node src/lib/warp/peer.check.mjs       OK   (sibling harness still green)
pnpm lint                              0 errors, 7 pre-existing react-refresh warnings
pnpm typecheck                         clean
pnpm --filter @warp/web build          built in 611ms
```

Because a passing test proves nothing until it can fail, I checked the asserts actually bite
by mutating `transfer.ts` three ways and confirming each one turns the harness red:

| Mutation | Result |
| --- | --- |
| encoder swapped for `JSON.stringify(...).length` | fails `multi-byte: frame is exactly envelope + UTF-8 payload` |
| JSON envelope dropped, bare text encoded | fails `empty snippet still costs the JSON envelope` |
| measurement shaved by one byte | fails `empty snippet still costs the JSON envelope` |

Each was reverted immediately and the harness returns to green; `transfer.ts` in this branch
is byte-identical to `main`.

One deliberate non-goal: the asserts derive the boundary from `TEXT_SNIPPET_MAX_BYTES` rather
than hard-coding 65536, so changing that constant does **not** fail the harness. The cap's
value is a product decision; what the harness locks is that the measurement around it is
exact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of transfer text snippets, including UTF-8 encoding, escaped content, size limits, and JSON envelope boundaries.
  * Added safer handling for default probe identifiers.
  * Updated validation success messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds focused pure-module coverage for text-snippet frame sizing without changing production behavior.
- Verifies JSON-envelope, UTF-8, and escaping byte costs.
- Exercises exact and over-limit snippet boundaries.
- Confirms generated transfer IDs cannot exceed the default probe ID’s byte length.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because it only expands test coverage and the new assertions match the current transfer-frame contracts.

The added tests import existing exports correctly and accurately exercise envelope size, UTF-8 encoding, JSON escaping, cap boundaries, and the bounded ASCII output of `fileId()`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/src/lib/warp/transfer.check.mjs | Adds coherent assertions for `textSnippetFrameBytes`, its size cap, and the probe-ID invariant; no actionable defect identified. |

<sub>Reviews (1): Last reviewed commit: ["test(transfer): cover textSnippetFrameBy..."](https://github.com/ishannaik/warp/commit/71b916f96e1908921b1853a7551f965603fd21e2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50830607)</sub>

<!-- /greptile_comment -->