### PR TITLE
docs(peer): update transfer and mesh header

### DIFF
--- a/web/src/lib/warp/peer.ts
+++ b/web/src/lib/warp/peer.ts
@@ -15,19 +15,20 @@
  * Because exactly one side ever creates the offer for a given pair, there is no
  * offer collision to resolve.
  *
- * Symmetric file transfer (review-before-receive redesign):
+ * Symmetric file transfer (review-before-receive):
  *   - EITHER peer can offer files at any time over the same open channel.
  *   - A send batch is GATED: the sender announces a manifest (`offer`), the
  *     receiver shows an accept modal, and only on `accept` do bytes flow. On
  *     `decline` nothing is sent.
- *   - Received files are accumulated into an in-memory Blob and handed to the
- *     UI via "file-received" — NOTHING auto-saves to disk. Downloading (one
- *     file, or a zip of all) is the UI's job now.
+ *   - Accepted receives flow through a `ReceiveHost`: the default path can keep
+ *     bytes in an in-memory Blob, while a supplied disk target streams them
+ *     straight to disk and emits `savedToDisk` on completion.
  *   - The channel STAYS OPEN after a batch: both peers can keep sending.
  *
- * v1 transport scope: 1-to-1 happy path. We connect to the first available peer
- * and route all transfers over that single channel. Multi-peer mesh is out of
- * scope.
+ * Mesh scope:
+ *   - One `WarpPeer` represents one remote-device connection.
+ *   - `useWarpTransfer` owns the full mesh: one `WarpPeer` per remote device,
+ *     with the glare-free initiator/responder role above applied to each pair.
  */
 
 import type { SignalData, SignalingClient } from "./signaling";


### PR DESCRIPTION
## What & why

Refresh the stale `peer.ts` module header so it matches the current receive and mesh architecture. The header now documents `ReceiveHost` memory/disk receive paths and the full mesh owned by `useWarpTransfer`, instead of claiming receives are memory-only and mesh is out of scope.

Closes #176

## Type

- [ ] feat
- [ ] fix
- [x] docs / chore / refactor / test / perf

## Checklist

- [ ] `pnpm lint && pnpm typecheck` pass locally
- [ ] `pnpm --filter @warp/web build` is green (web changes)
- [ ] Engine changes: the relevant `web/src/lib/warp/*.check.mjs` harness passes (and covers the new behaviour)

This is a comments-only change with no executable-code or behaviour changes; local checks were not run from this environment. CI can validate lint/typecheck/build on the PR.

### Hard constraints (see [CONTRIBUTING.md](../CONTRIBUTING.md#hard-constraints-the-soul-of-the-project))

- [x] No new recurring-cost infrastructure — no TURN, database, storage, or paid API ($0, no card, forever)
- [x] Still STUN-only — no relay in the file path; NAT failure stays an honest error
- [x] The signaling server still never reads, stores, or understands file contents
- [x] `SEND_HIGH_WATER` in `peer.ts` untouched and still well below 16 MiB
- [x] Transient network drops still recover (no new terminal errors for blips; keepalive ping intact)

## Screenshots / recordings

Not applicable — documentation comments only; no UI or runtime behaviour changed.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR updates the `peer.ts` module header to match the current receive and mesh architecture.
- Documents memory-backed and disk-streamed receive paths through `ReceiveHost`.
- Clarifies that `useWarpTransfer` owns a full mesh with one `WarpPeer` per remote device.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the comments accurately reflect the existing implementation and introduce no runtime behavior changes.

The updated documentation is consistent with the existing `ReceiveHost` memory and disk paths and the mesh managed by `useWarpTransfer`; no actionable defects remain.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/src/lib/warp/peer.ts | The revised header accurately describes the existing receive and multi-peer mesh implementations without changing executable behavior. |

<sub>Reviews (1): Last reviewed commit: ["docs(peer): update transfer and mesh hea..."](https://github.com/ishannaik/warp/commit/1eafb70abee965b5bb6033a3f639121a62a10a63) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51112701)</sub>

<!-- /greptile_comment -->