### PR TITLE
docs: add governance transparency note

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ Warp is open source and **we welcome PRs**, from a one-line typo fix to engine w
 
 ---
 
+## Governance & privacy
+
+Warp is MIT-licensed, and its privacy guarantee comes from its architecture rather than a policy promise. The project's $0, no-TURN, and no-storage constraints keep file bytes out of Warp's infrastructure; introducing a hosted file relay or storage tier would require a visible architecture change, not a quiet policy edit. See [SECURITY.md](./SECURITY.md) and [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md) for the trust boundary and technical design.
+
 ## Why it's different
 
 - 🔒 **End-to-end encrypted by default.** Every transfer rides DTLS on the WebRTC data channel, and the keys live only in the two browsers. Your ISP, the café Wi-Fi, and Warp itself all see nothing but ciphertext.


### PR DESCRIPTION
## What & why

Add a short governance and privacy paragraph near the top of the README. It makes the MIT license and Warp's $0 / no-TURN / no-storage architecture explicit as the basis of the privacy guarantee, and links to the security and architecture docs for technical detail.

Closes #118

## Type

- [ ] feat
- [ ] fix
- [x] docs / chore / refactor / test / perf

## Checklist

This is a README-only documentation change. No runtime, UI, server, or transfer-engine behavior changed, so code/build checks are not applicable to the diff.

### Hard constraints

- [x] No new recurring-cost infrastructure — no TURN, database, storage, or paid API
- [x] Still STUN-only — no relay in the file path
- [x] The signaling server still never reads, stores, or understands file contents
- [x] `SEND_HIGH_WATER` untouched
- [x] Transient network behavior untouched

## Screenshots / recordings

Not applicable — README-only change.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds a governance and privacy section near the top of the README.
- Grounds the privacy guarantee in Warp’s MIT-licensed, STUN-only, no-file-storage architecture.
- Links readers to the security and architecture documentation for technical details.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the documentation accurately reflects Warp’s current license and file-transfer architecture.

The new README claims are supported by the license, security documentation, architecture documentation, and current STUN-only implementation, with no broken references or misleading file-byte privacy guarantees identified.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Adds an accurate governance and privacy note consistent with the repository’s license, architecture, and trust-boundary documentation. |

<sub>Reviews (1): Last reviewed commit: ["docs: add governance transparency note"](https://github.com/ishannaik/warp/commit/bb525205f09c728baf146b97bab33a15b1fa996e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51116487)</sub>

<!-- /greptile_comment -->