### PR TITLE
fix(landing): replace the false RELAY FALLBACK card with honest-failure copy (#173)

### DIFF
--- a/web/src/sections/Architecture.tsx
+++ b/web/src/sections/Architecture.tsx
@@ -323,10 +323,10 @@ export default function Architecture() {
             </p>
           </div>
           <div style={cardBase}>
-            <div style={cardLabel}>RELAY FALLBACK</div>
+            <div style={cardLabel}>HONEST FAILURE</div>
             <p style={cardBody}>
-              If a direct path can&rsquo;t form, an encrypted relay finishes the
-              job &mdash; still unreadable to us.
+              If a direct path can&rsquo;t form, Warp tells you plainly. There
+              is no relay to fall back to, on purpose.
             </p>
           </div>
         </div>


### PR DESCRIPTION
Closes #173.

The Architecture band shipped a card promising visitors that "an encrypted relay finishes the job" when a direct path fails. Warp is STUN-only and runs no TURN relay, so that was false — and it contradicted the FAQ answer further down the same page.

## The change

Label and copy only, in the same visual style:

| | |
|---|---|
| **was** | `RELAY FALLBACK` — "If a direct path can't form, an encrypted relay finishes the job — still unreadable to us." |
| **now** | `HONEST FAILURE` — "If a direct path can't form, Warp tells you plainly. There is no relay to fall back to, on purpose." |

The new wording reuses the FAQ's own phrase — *"There isn't a relay to fall back to, on purpose"* (`Faq.tsx:100`) — so the two now read as one voice rather than two contradicting each other.

The mobile grid branch (`isMobile ? "1fr" : "repeat(3,1fr)"`) is untouched.

## Acceptance criteria

- [x] **No landing copy claims a relay finishes failed transfers.** I checked this more broadly than the two literal strings, since a grep for those alone would pass while a paraphrase survived. Every remaining `relay` hit under `web/src/` is accurate: the *signaling* relay that brokers the handshake (`Architecture.tsx:76,108`, `HowItWorks.tsx:149`, `signaling.ts`), and the `/how` theory pages explaining why a TURN relay costs money and Warp runs none. `TransferFlow.tsx:1082` already told users "Warp is STUN-only — there's no relay fallback", so this card was the only place on the site still saying otherwise.
- [x] **Third card still fits the desktop row and stacks cleanly at ~360–430px.** Measured in-browser against the built bundle rather than eyeballed — `getBoundingClientRect` on all three cards:

  | viewport | grid | card widths | card heights | horizontal overflow |
  |---|---|---|---|---|
  | 1512 | `428px 428px 428px` | 428 / 428 / 428 | 115 / 115 / **115** | none |
  | 430 | `394px` (stacked) | 394 / 394 / 394 | 115 / 115 / **115** | none |
  | 390 | `354px` (stacked) | 354 / 354 / 354 | 136 / 115 / **115** | none |
  | 360 | `324px` (stacked) | 324 / 324 / 324 | 136 / 136 / **136** | none |

  The new card is never the tallest of the three at any width, and `document.scrollWidth === clientWidth` at all four.
- [x] **Wording stays consistent with the FAQ answer** — it borrows that answer's exact clause.
- [x] **`grep -rn "RELAY FALLBACK\|encrypted relay finishes" web/src/` returns nothing.** Also verified in the rendered DOM, not just the source: querying the live page for either string returns 0 nodes.

## Checks

All four from CONTRIBUTING, on this branch:

- `pnpm lint` — 0 errors (7 pre-existing `react-refresh/only-export-components` warnings, none in this file)
- `pnpm typecheck` — clean
- `pnpm --filter @warp/web build` — green
- `pnpm --filter @warp/server test` — not run; this touches no server code and CI is path-filtered

One note on how I verified the layout, since it nearly went wrong: my first pass resized the browser window to 390px and screenshotted, and the screenshot looked fine — but `window.innerWidth` was still 1512. The window resize had not reached the page, so I was reading the desktop layout and about to call it a mobile check. The numbers above come from real device-metrics emulation, where `innerWidth` actually reports 360/390/430.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the architecture information to clarify that direct-connection failures do not fall back to relays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Replaces the inaccurate relay-fallback claim with copy that truthfully describes Warp’s behavior when a direct connection cannot form.
- Renames the third architecture card from `RELAY FALLBACK` to `HONEST FAILURE`.
- States that Warp reports direct-connection failures instead of falling back to a relay.
- Leaves component logic, styling, and responsive layout unchanged.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The change is limited to accurate static copy and does not alter component behavior, styling, responsive layout, data flow, or security boundaries.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/src/sections/Architecture.tsx | The static copy now accurately reflects Warp’s STUN-only behavior and remains consistent with the FAQ and runtime messaging. |

<sub>Reviews (1): Last reviewed commit: ["fix(landing): replace the false RELAY FA..."](https://github.com/ishannaik/warp/commit/e197bac8029a44dbb71281c7640cd6ea110d7c64) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51140681)</sub>

<!-- /greptile_comment -->