### PR TITLE
fix(server): refuse malformed signal frames instead of dropping them (#189)

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -172,6 +172,14 @@ export class SignalingRoom {
   }
 
   handleSignal(ws, msg) {
+    // Refuse obviously malformed frames. A non-string `to` just failed the lookup below
+    // and vanished silently; a missing `data` still reached the peer as `data: undefined`,
+    // which every client then had to special-case. `data` itself stays opaque — this
+    // checks that the key is present, never what is inside it, so `null` is a value and
+    // relays normally.
+    if (typeof msg.to !== 'string' || msg.data === undefined) {
+      return this.send(ws, { type: 'error', error: 'bad-message', message: 'signal requires to + data.' });
+    }
     const a = ws.deserializeAttachment();
     if (!a) return;
     // Relay to the target peer if it's reachable from this sender: either same room,

--- a/server/test.js
+++ b/server/test.js
@@ -136,7 +136,45 @@ async function run() {
   e.close();
   f.close();
 
-  for (const ws of [a, c, d]) ws.close();
+  // 9. Malformed `signal` frames are refused instead of silently dropped or half-relayed.
+  //    A non-string `to` used to fail the peer lookup and disappear with no reply; a
+  //    missing `data` still reached the peer as `data: undefined`.
+  const s1 = await connect();
+  sendj(s1, { type: 'join' });
+  const s1j = await next(s1, (m) => m.type === 'joined');
+  const s2 = await connect();
+  sendj(s2, { type: 'join', room: s1j.room });
+  const s2j = await next(s2, (m) => m.type === 'joined');
+  await next(s1, (m) => m.type === 'peer-joined');
+
+  for (const bad of [
+    { type: 'signal', to: 42, data: { sdp: 'x' } },
+    { type: 'signal', to: null, data: { sdp: 'x' } },
+    { type: 'signal', to: { id: s1j.selfId }, data: { sdp: 'x' } },
+    { type: 'signal', to: [s1j.selfId], data: { sdp: 'x' } },
+    { type: 'signal', data: { sdp: 'x' } },              // no `to` at all
+    { type: 'signal', to: s1j.selfId },                  // no `data` at all
+  ]) {
+    sendj(s2, bad);
+    const err = await next(s2, (m) => m.type === 'error');
+    assert.equal(err.error, 'bad-message', `rejects ${JSON.stringify(bad)}`);
+  }
+  await delay(300);
+  assert.equal(s1.queue.filter((m) => m.type === 'signal').length, 0, 'no malformed frame reached the peer');
+
+  // The guard must not have broken the relay path it sits in front of.
+  sendj(s2, { type: 'signal', to: s1j.selfId, data: { sdp: 'ok' } });
+  const good = await next(s1, (m) => m.type === 'signal');
+  assert.equal(good.from, s2j.selfId, 'a valid frame still relays with a server-stamped from');
+  assert.deepEqual(good.data, { sdp: 'ok' }, 'valid payload relayed intact');
+
+  // `data: null` is a present value, not an absence. The guard checks for the key, not
+  // its contents, so null relays — that is what keeping `data` opaque means.
+  sendj(s2, { type: 'signal', to: s1j.selfId, data: null });
+  const nulled = await next(s1, (m) => m.type === 'signal');
+  assert.equal(nulled.data, null, 'null data relays — the guard never inspects the payload');
+
+  for (const ws of [a, c, d, s1, s2]) ws.close();
 }
 
 // Local mode boots `wrangler dev`; remote mode (TEST_WS_URL set) tests a deployed Worker.


### PR DESCRIPTION
Closes #189.

`handleSignal` trusted `msg.to` and `msg.data`. A non-string `to` failed the peer lookup and vanished with no reply to the sender; a missing `data` was still forwarded as `{ type:"signal", from, data: undefined }`, so clients had to special-case it.

Both now get `{ error: "bad-message" }` and are not forwarded.

```js
if (typeof msg.to !== "string" || msg.data === undefined) {
  return this.send(ws, { type: "error", error: "bad-message", message: "signal requires to + data." });
}
```

Placed at the top of `handleSignal`, as suggested. The same-room / same-network relay rules and the server-stamped `from` are untouched.

## One boundary worth naming

The guard checks that `data` is **present**, never what is inside it — so `data: null` is a value and relays normally. Only a genuinely absent key is refused. That is the line "keep `data` opaque" draws, and since it is the kind of thing a future reader would otherwise have to rediscover, there is a test pinning it rather than just a comment.

## Acceptance criteria

- [x] Non-string `to` or missing `data` gets `bad-message` and is not forwarded
- [x] Valid signal frames still relay with a server-stamped `from`
- [x] `data` remains opaque — no JSON deep validation
- [x] Existing server tests pass

## Tests

Extended `server/test.js` with a section 8 covering six rejected shapes — `to` as number, `null`, object, array, absent, and `data` absent — then asserting the peer received **no** `signal` at all, that a valid frame still relays intact afterward, and the `data: null` boundary above.

`pnpm --filter @warp/server test` → `✓ all signaling tests passed`. `pnpm lint` 0 errors, `pnpm typecheck` clean.

## I checked the tests actually fail without the fix

A green suite proves nothing on its own — it has to fail when the fix is removed. So I committed the fix first, then mutated it twice and re-ran, restoring from the commit each time:

| mutation | result |
|---|---|
| remove the guard entirely | **fails** — `timeout waiting for message` (no error ever sent) |
| keep `typeof msg.to !== "string"`, drop `msg.data === undefined` | **fails** — same |

The second one matters more than the first: without it I would only have shown that *some* guard is needed, not that the `data` half is independently covered. The working tree was restored from the commit after each run and `git diff` against it is empty.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for signaling messages with missing or invalid recipient fields or missing data.
  - Malformed messages now receive a clear error and are not relayed.
  - Valid messages, including those with `null` data, continue to be delivered unchanged.

- **Tests**
  - Added coverage for malformed and valid signaling scenarios, including connection cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR validates signal frames before peer lookup, returning `bad-message` for a non-string destination or absent data while preserving opaque payload relay.
- Adds early malformed-frame rejection to `handleSignal`.
- Adds coverage for invalid destinations, absent fields, valid relaying, server-stamped sender identity, and `null` payload behavior.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/index.js | Adds an early signal-frame guard while leaving the existing authorization and relay path unchanged. |
| server/test.js | Exercises malformed signal rejection, non-forwarding, valid recovery, sender stamping, and opaque null payload relay. |

<sub>Reviews (2): Last reviewed commit: ["fix(server): refuse malformed signal fra..."](https://github.com/ishannaik/warp/commit/d57533ef2661bc8cffdfb4e42679e056194a8b63) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51141244)</sub>

<!-- /greptile_comment -->