### PR TITLE
fix(checks): let build and import errors fail the engine harnesses (#229)

### DIFF
--- a/web/src/lib/warp/compress.check.mjs
+++ b/web/src/lib/warp/compress.check.mjs
@@ -15,21 +15,22 @@ import url from "node:url";
 const here = path.dirname(url.fileURLToPath(import.meta.url));
 
 let supportedCodecs, isCompressible, chooseCodec, compressChunk, decompressChunk;
+let esbuild;
 try {
-  const esbuild = await import("esbuild");
-  const out = await esbuild.build({
-    entryPoints: [path.join(here, "compress.ts")],
-    bundle: true,
-    format: "esm",
-    write: false,
-    platform: "neutral",
-  });
-  const dataUrl = "data:text/javascript;base64," + Buffer.from(out.outputFiles[0].text).toString("base64");
-  ({ supportedCodecs, isCompressible, chooseCodec, compressChunk, decompressChunk } = await import(dataUrl));
+  esbuild = await import("esbuild");
 } catch (e) {
   console.error("SKIP: esbuild not available —", e.message);
   process.exit(0);
 }
+const out = await esbuild.build({
+  entryPoints: [path.join(here, "compress.ts")],
+  bundle: true,
+  format: "esm",
+  write: false,
+  platform: "neutral",
+});
+const dataUrl = "data:text/javascript;base64," + Buffer.from(out.outputFiles[0].text).toString("base64");
+({ supportedCodecs, isCompressible, chooseCodec, compressChunk, decompressChunk } = await import(dataUrl));
 
 // --- isCompressible: an allowlist, raw when in doubt ------------------------------
 assert.equal(isCompressible("text/plain"), true, "text/plain compresses");

--- a/web/src/lib/warp/hash.check.mjs
+++ b/web/src/lib/warp/hash.check.mjs
@@ -18,25 +18,26 @@ import assert from "node:assert";
 import { createHash, randomBytes } from "node:crypto";
 
 let init, update, finalize, toHex;
+let esbuild;
 try {
-  const esbuild = await import("esbuild");
-  const url = await import("node:url");
-  const path = await import("node:path");
-  const here = path.dirname(url.fileURLToPath(import.meta.url));
-  const out = await esbuild.build({
-    entryPoints: [path.join(here, "sha256.ts")],
-    bundle: true,
-    format: "esm",
-    write: false,
-    platform: "neutral",
-  });
-  const code = out.outputFiles[0].text;
-  const dataUrl = "data:text/javascript;base64," + Buffer.from(code).toString("base64");
-  ({ init, update, finalize, toHex } = await import(dataUrl));
+  esbuild = await import("esbuild");
 } catch (e) {
   console.error("SKIP: esbuild not available —", e.message);
   process.exit(0);
 }
+const url = await import("node:url");
+const path = await import("node:path");
+const here = path.dirname(url.fileURLToPath(import.meta.url));
+const out = await esbuild.build({
+  entryPoints: [path.join(here, "sha256.ts")],
+  bundle: true,
+  format: "esm",
+  write: false,
+  platform: "neutral",
+});
+const code = out.outputFiles[0].text;
+const dataUrl = "data:text/javascript;base64," + Buffer.from(code).toString("base64");
+({ init, update, finalize, toHex } = await import(dataUrl));
 
 const enc = new TextEncoder();
 const hex = (bytes) => toHex(bytes);

--- a/web/src/lib/warp/idbStage.check.mjs
+++ b/web/src/lib/warp/idbStage.check.mjs
@@ -16,24 +16,25 @@ const nav = { userAgent: "", maxTouchPoints: 0, storage: { estimate: async () =>
 Object.defineProperty(globalThis, "navigator", { value: nav, configurable: true, writable: true });
 
 let estimateFits, storageFits;
+let esbuild;
 try {
-  const esbuild = await import("esbuild");
-  const url = await import("node:url");
-  const path = await import("node:path");
-  const here = path.dirname(url.fileURLToPath(import.meta.url));
-  const out = await esbuild.build({
-    entryPoints: [path.join(here, "idbStage.ts")],
-    bundle: true,
-    format: "esm",
-    write: false,
-    platform: "neutral",
-  });
-  const dataUrl = "data:text/javascript;base64," + Buffer.from(out.outputFiles[0].text).toString("base64");
-  ({ estimateFits, storageFits } = await import(dataUrl));
+  esbuild = await import("esbuild");
 } catch (e) {
   console.error("SKIP: esbuild not available —", e.message);
   process.exit(0);
 }
+const url = await import("node:url");
+const path = await import("node:path");
+const here = path.dirname(url.fileURLToPath(import.meta.url));
+const out = await esbuild.build({
+  entryPoints: [path.join(here, "idbStage.ts")],
+  bundle: true,
+  format: "esm",
+  write: false,
+  platform: "neutral",
+});
+const dataUrl = "data:text/javascript;base64," + Buffer.from(out.outputFiles[0].text).toString("base64");
+({ estimateFits, storageFits } = await import(dataUrl));
 
 // --- iOS hard memory cap: refuse a multi-GB file even if storage says fine --------
 nav.userAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15";

--- a/web/src/lib/warp/idbStage.sink.check.mjs
+++ b/web/src/lib/warp/idbStage.sink.check.mjs
@@ -165,24 +165,25 @@ globalThis.IDBKeyRange = { bound: (lower, upper) => ({ lower, upper }) };
 
 // --- load idbStage.ts (esbuild-bundled, as the other harnesses do) --------------
 let idbSink, gcOrphanStaging, idbDurableLength;
+let esbuild;
 try {
-  const esbuild = await import("esbuild");
-  const url = await import("node:url");
-  const path = await import("node:path");
-  const here = path.dirname(url.fileURLToPath(import.meta.url));
-  const out = await esbuild.build({
-    entryPoints: [path.join(here, "idbStage.ts")],
-    bundle: true,
-    format: "esm",
-    write: false,
-    platform: "neutral",
-  });
-  const dataUrl = "data:text/javascript;base64," + Buffer.from(out.outputFiles[0].text).toString("base64");
-  ({ idbSink, gcOrphanStaging, idbDurableLength } = await import(dataUrl));
+  esbuild = await import("esbuild");
 } catch (e) {
   console.error("SKIP: esbuild not available —", e.message);
   process.exit(0);
 }
+const url = await import("node:url");
+const path = await import("node:path");
+const here = path.dirname(url.fileURLToPath(import.meta.url));
+const out = await esbuild.build({
+  entryPoints: [path.join(here, "idbStage.ts")],
+  bundle: true,
+  format: "esm",
+  write: false,
+  platform: "neutral",
+});
+const dataUrl = "data:text/javascript;base64," + Buffer.from(out.outputFiles[0].text).toString("base64");
+({ idbSink, gcOrphanStaging, idbDurableLength } = await import(dataUrl));
 
 const enc = new TextEncoder();
 const bytes = async (blob) => new Uint8Array(await blob.arrayBuffer());

--- a/web/src/lib/warp/opfsStage.check.mjs
+++ b/web/src/lib/warp/opfsStage.check.mjs
@@ -24,24 +24,25 @@ class FakeWorker {}
 globalThis.Worker = FakeWorker;
 
 let opfsSupported, opfsSink, opfsDurableLength, opfsSinkWithIdbFallback;
+let esbuild;
 try {
-  const esbuild = await import("esbuild");
-  const url = await import("node:url");
-  const path = await import("node:path");
-  const here = path.dirname(url.fileURLToPath(import.meta.url));
-  const out = await esbuild.build({
-    entryPoints: [path.join(here, "opfsStage.ts")],
-    bundle: true,
-    format: "esm",
-    write: false,
-    platform: "neutral",
-  });
-  const dataUrl = "data:text/javascript;base64," + Buffer.from(out.outputFiles[0].text).toString("base64");
-  ({ opfsSupported, opfsSink, opfsDurableLength, opfsSinkWithIdbFallback } = await import(dataUrl));
+  esbuild = await import("esbuild");
 } catch (e) {
   console.error("SKIP: esbuild not available —", e.message);
   process.exit(0);
 }
+const url = await import("node:url");
+const path = await import("node:path");
+const here = path.dirname(url.fileURLToPath(import.meta.url));
+const out = await esbuild.build({
+  entryPoints: [path.join(here, "opfsStage.ts")],
+  bundle: true,
+  format: "esm",
+  write: false,
+  platform: "neutral",
+});
+const dataUrl = "data:text/javascript;base64," + Buffer.from(out.outputFiles[0].text).toString("base64");
+({ opfsSupported, opfsSink, opfsDurableLength, opfsSinkWithIdbFallback } = await import(dataUrl));
 
 const buf = (s) => new TextEncoder().encode(s).buffer;
 

--- a/web/src/lib/warp/peer.check.mjs
+++ b/web/src/lib/warp/peer.check.mjs
@@ -71,28 +71,29 @@ if (typeof globalThis.document === "undefined") globalThis.document = undefined;
 
 // --- transpile peer.ts/transfer.ts on the fly (esbuild if present) --------
 let WarpPeer;
+let esbuild;
 try {
-  const esbuild = await import("esbuild");
-  const fs = await import("node:fs/promises");
-  const url = await import("node:url");
-  const path = await import("node:path");
-  const here = path.dirname(url.fileURLToPath(import.meta.url));
-  const out = await esbuild.build({
-    entryPoints: [path.join(here, "peer.ts")],
-    bundle: true,
-    format: "esm",
-    write: false,
-    platform: "neutral",
-    // signaling.ts is type-only at runtime here; let it bundle.
-  });
-  const code = out.outputFiles[0].text;
-  const dataUrl = "data:text/javascript;base64," + Buffer.from(code).toString("base64");
-  ({ WarpPeer } = await import(dataUrl));
-  void fs;
+  esbuild = await import("esbuild");
 } catch (e) {
   console.error("SKIP: esbuild not available to transpile TS for this check —", e.message);
   process.exit(0);
 }
+const fs = await import("node:fs/promises");
+const url = await import("node:url");
+const path = await import("node:path");
+const here = path.dirname(url.fileURLToPath(import.meta.url));
+const out = await esbuild.build({
+  entryPoints: [path.join(here, "peer.ts")],
+  bundle: true,
+  format: "esm",
+  write: false,
+  platform: "neutral",
+  // signaling.ts is type-only at runtime here; let it bundle.
+});
+const code = out.outputFiles[0].text;
+const dataUrl = "data:text/javascript;base64," + Buffer.from(code).toString("base64");
+({ WarpPeer } = await import(dataUrl));
+void fs;
 
 // --- wire two peers through fake channels ---------------------------------
 // Record out-of-band signaling sends so we can assert the instant-cancel path.

--- a/web/src/lib/warp/pieceManifest.check.mjs
+++ b/web/src/lib/warp/pieceManifest.check.mjs
@@ -15,25 +15,26 @@ import assert from "node:assert";
 
 // --- transpile pieceManifest.ts (+ sha256.ts) on the fly --------------------
 let mod;
+let esbuild;
 try {
-  const esbuild = await import("esbuild");
-  const url = await import("node:url");
-  const path = await import("node:path");
-  const here = path.dirname(url.fileURLToPath(import.meta.url));
-  const out = await esbuild.build({
-    entryPoints: [path.join(here, "pieceManifest.ts")],
-    bundle: true,
-    format: "esm",
-    write: false,
-    platform: "neutral",
-  });
-  const code = out.outputFiles[0].text;
-  const dataUrl = "data:text/javascript;base64," + Buffer.from(code).toString("base64");
-  mod = await import(dataUrl);
+  esbuild = await import("esbuild");
 } catch (e) {
   console.error("SKIP: esbuild not available to transpile TS for this check —", e.message);
   process.exit(0);
 }
+const url = await import("node:url");
+const path = await import("node:path");
+const here = path.dirname(url.fileURLToPath(import.meta.url));
+const out = await esbuild.build({
+  entryPoints: [path.join(here, "pieceManifest.ts")],
+  bundle: true,
+  format: "esm",
+  write: false,
+  platform: "neutral",
+});
+const code = out.outputFiles[0].text;
+const dataUrl = "data:text/javascript;base64," + Buffer.from(code).toString("base64");
+mod = await import(dataUrl);
 
 const {
   PIECE_SIZE,

--- a/web/src/lib/warp/receiveController.check.mjs
+++ b/web/src/lib/warp/receiveController.check.mjs
@@ -10,25 +10,26 @@
 import assert from "node:assert";
 
 let memorySink, diskSink;
+let esbuild;
 try {
-  const esbuild = await import("esbuild");
-  const url = await import("node:url");
-  const path = await import("node:path");
-  const here = path.dirname(url.fileURLToPath(import.meta.url));
-  const out = await esbuild.build({
-    entryPoints: [path.join(here, "receiveController.ts")],
-    bundle: true,
-    format: "esm",
-    write: false,
-    platform: "neutral",
-  });
-  const code = out.outputFiles[0].text;
-  const dataUrl = "data:text/javascript;base64," + Buffer.from(code).toString("base64");
-  ({ memorySink, diskSink } = await import(dataUrl));
+  esbuild = await import("esbuild");
 } catch (e) {
   console.error("SKIP: esbuild not available —", e.message);
   process.exit(0);
 }
+const url = await import("node:url");
+const path = await import("node:path");
+const here = path.dirname(url.fileURLToPath(import.meta.url));
+const out = await esbuild.build({
+  entryPoints: [path.join(here, "receiveController.ts")],
+  bundle: true,
+  format: "esm",
+  write: false,
+  platform: "neutral",
+});
+const code = out.outputFiles[0].text;
+const dataUrl = "data:text/javascript;base64," + Buffer.from(code).toString("base64");
+({ memorySink, diskSink } = await import(dataUrl));
 
 const buf = (s) => new TextEncoder().encode(s).buffer;
 

--- a/web/src/lib/warp/receiveStrategy.check.mjs
+++ b/web/src/lib/warp/receiveStrategy.check.mjs
@@ -15,21 +15,22 @@ import url from "node:url";
 const here = path.dirname(url.fileURLToPath(import.meta.url));
 
 let LARGE_THRESHOLD, detectFsAccessSupport, isLargeBatch, chooseReceiveStrategy;
+let esbuild;
 try {
-  const esbuild = await import("esbuild");
-  const out = await esbuild.build({
-    entryPoints: [path.join(here, "receiveStrategy.ts")],
-    bundle: true,
-    format: "esm",
-    write: false,
-    platform: "neutral",
-  });
-  const dataUrl = "data:text/javascript;base64," + Buffer.from(out.outputFiles[0].text).toString("base64");
-  ({ LARGE_THRESHOLD, detectFsAccessSupport, isLargeBatch, chooseReceiveStrategy } = await import(dataUrl));
+  esbuild = await import("esbuild");
 } catch (e) {
   console.error("SKIP: esbuild not available —", e.message);
   process.exit(0);
 }
+const out = await esbuild.build({
+  entryPoints: [path.join(here, "receiveStrategy.ts")],
+  bundle: true,
+  format: "esm",
+  write: false,
+  platform: "neutral",
+});
+const dataUrl = "data:text/javascript;base64," + Buffer.from(out.outputFiles[0].text).toString("base64");
+({ LARGE_THRESHOLD, detectFsAccessSupport, isLargeBatch, chooseReceiveStrategy } = await import(dataUrl));
 
 const MiB = 1024 * 1024;
 assert.equal(LARGE_THRESHOLD, 256 * MiB, "LARGE_THRESHOLD is the shared 256 MiB line");

--- a/web/src/lib/warp/rxLedger.check.mjs
+++ b/web/src/lib/warp/rxLedger.check.mjs
@@ -121,24 +121,25 @@ globalThis.indexedDB = {
 
 // --- load rxLedger.ts (esbuild-bundled, as the other harnesses do) --------------
 let putRxLedger, readRxLedger, removeRxLedger, gcRxLedger;
+let esbuild;
 try {
-  const esbuild = await import("esbuild");
-  const url = await import("node:url");
-  const path = await import("node:path");
-  const here = path.dirname(url.fileURLToPath(import.meta.url));
-  const out = await esbuild.build({
-    entryPoints: [path.join(here, "rxLedger.ts")],
-    bundle: true,
-    format: "esm",
-    write: false,
-    platform: "neutral",
-  });
-  const dataUrl = "data:text/javascript;base64," + Buffer.from(out.outputFiles[0].text).toString("base64");
-  ({ putRxLedger, readRxLedger, removeRxLedger, gcRxLedger } = await import(dataUrl));
+  esbuild = await import("esbuild");
 } catch (e) {
   console.error("SKIP: esbuild not available —", e.message);
   process.exit(0);
 }
+const url = await import("node:url");
+const path = await import("node:path");
+const here = path.dirname(url.fileURLToPath(import.meta.url));
+const out = await esbuild.build({
+  entryPoints: [path.join(here, "rxLedger.ts")],
+  bundle: true,
+  format: "esm",
+  write: false,
+  platform: "neutral",
+});
+const dataUrl = "data:text/javascript;base64," + Buffer.from(out.outputFiles[0].text).toString("base64");
+({ putRxLedger, readRxLedger, removeRxLedger, gcRxLedger } = await import(dataUrl));
 
 const ledgerStore = () => db.stores.get("ledger");
 const row = (key, room, extra = {}) => ({

--- a/web/src/lib/warp/signaling.check.mjs
+++ b/web/src/lib/warp/signaling.check.mjs
@@ -32,24 +32,25 @@ globalThis.window = { addEventListener() {}, removeEventListener() {} };
 if (typeof globalThis.document === "undefined") globalThis.document = { addEventListener() {}, removeEventListener() {} };
 
 let SignalingClient;
+let esbuild;
 try {
-  const esbuild = await import("esbuild");
-  const url = await import("node:url");
-  const path = await import("node:path");
-  const here = path.dirname(url.fileURLToPath(import.meta.url));
-  const out = await esbuild.build({
-    entryPoints: [path.join(here, "signaling.ts")],
-    bundle: true,
-    format: "esm",
-    write: false,
-    platform: "neutral",
-  });
-  const dataUrl = "data:text/javascript;base64," + Buffer.from(out.outputFiles[0].text).toString("base64");
-  ({ SignalingClient } = await import(dataUrl));
+  esbuild = await import("esbuild");
 } catch (e) {
   console.error("SKIP: esbuild not available —", e.message);
   process.exit(0);
 }
+const url = await import("node:url");
+const path = await import("node:path");
+const here = path.dirname(url.fileURLToPath(import.meta.url));
+const out = await esbuild.build({
+  entryPoints: [path.join(here, "signaling.ts")],
+  bundle: true,
+  format: "esm",
+  write: false,
+  platform: "neutral",
+});
+const dataUrl = "data:text/javascript;base64," + Buffer.from(out.outputFiles[0].text).toString("base64");
+({ SignalingClient } = await import(dataUrl));
 
 // --- 1. Once joined (room set), reconnect NEVER gives up ------------------
 {

--- a/web/src/lib/warp/transfer.check.mjs
+++ b/web/src/lib/warp/transfer.check.mjs
@@ -9,25 +9,26 @@ import assert from "node:assert";
 
 // --- transpile transfer.ts on the fly (esbuild if present) ----------------
 let mod;
+let esbuild;
 try {
-  const esbuild = await import("esbuild");
-  const url = await import("node:url");
-  const path = await import("node:path");
-  const here = path.dirname(url.fileURLToPath(import.meta.url));
-  const out = await esbuild.build({
-    entryPoints: [path.join(here, "transfer.ts")],
-    bundle: true,
-    format: "esm",
-    write: false,
-    platform: "neutral",
-  });
-  const code = out.outputFiles[0].text;
-  const dataUrl = "data:text/javascript;base64," + Buffer.from(code).toString("base64");
-  mod = await import(dataUrl);
+  esbuild = await import("esbuild");
 } catch (e) {
   console.error("SKIP: esbuild not available to transpile TS for this check —", e.message);
   process.exit(0);
 }
+const url = await import("node:url");
+const path = await import("node:path");
+const here = path.dirname(url.fileURLToPath(import.meta.url));
+const out = await esbuild.build({
+  entryPoints: [path.join(here, "transfer.ts")],
+  bundle: true,
+  format: "esm",
+  write: false,
+  platform: "neutral",
+});
+const code = out.outputFiles[0].text;
+const dataUrl = "data:text/javascript;base64," + Buffer.from(code).toString("base64");
+mod = await import(dataUrl);
 
 const { fileKey, newResumeToken, formatBytes, textSnippetFrameBytes, TEXT_SNIPPET_MAX_BYTES, fileId } =
   mod;

--- a/web/src/lib/warp/zipDownload.check.mjs
+++ b/web/src/lib/warp/zipDownload.check.mjs
@@ -32,25 +32,26 @@ globalThis.URL.revokeObjectURL = () => {};
 
 // --- transpile zipDownload.ts on the fly (esbuild if present) --------------
 let streamZipDownload;
+let esbuild;
 try {
-  const esbuild = await import("esbuild");
-  const path = await import("node:path");
-  const url = await import("node:url");
-  const here = path.dirname(url.fileURLToPath(import.meta.url));
-  const out = await esbuild.build({
-    entryPoints: [path.join(here, "zipDownload.ts")],
-    bundle: true,
-    format: "esm",
-    write: false,
-    platform: "neutral",
-  });
-  const code = out.outputFiles[0].text;
-  const dataUrl = "data:text/javascript;base64," + Buffer.from(code).toString("base64");
-  ({ streamZipDownload } = await import(dataUrl));
+  esbuild = await import("esbuild");
 } catch (e) {
   console.error("SKIP: esbuild not available to transpile TS for this check —", e.message);
   process.exit(0);
 }
+const path = await import("node:path");
+const url = await import("node:url");
+const here = path.dirname(url.fileURLToPath(import.meta.url));
+const out = await esbuild.build({
+  entryPoints: [path.join(here, "zipDownload.ts")],
+  bundle: true,
+  format: "esm",
+  write: false,
+  platform: "neutral",
+});
+const code = out.outputFiles[0].text;
+const dataUrl = "data:text/javascript;base64," + Buffer.from(code).toString("base64");
+({ streamZipDownload } = await import(dataUrl));
 
 // fflate's synchronous unzip, for verifying the streamed archive. Resolves from
 // the same dependency the helper bundles.


### PR DESCRIPTION
## What & why

The `try` around the esbuild import also wrapped the build and the dynamic import, so any failure inside it hit the `catch`, printed "esbuild not available" and exited 0. A module that failed to compile reported a skip and passed the gate.

Narrowed the `try` to `await import("esbuild")` exactly as you specified. The build and the module import now run at top level and throw.

Applied to the 13 harnesses carrying the pattern. `useNearby` and `useWarpTransfer` don't have it and are untouched — that matches your list. **No assertion changed anywhere**; this is the transpile preamble only.

One small deviation worth flagging: each file keeps **its own** SKIP wording rather than being homogenised. `compress` and `receiveStrategy` say `"SKIP: esbuild not available —"` where the others say `"SKIP: esbuild not available to transpile TS for this check —"`. Rewording them would have been a change you didn't ask for.

Closes #229

## Type

- [ ] feat
- [x] fix
- [ ] docs / chore / refactor / test / perf

## What I tested

The bug here is a check that reported success without verifying anything, so I proved each acceptance criterion instead of asserting it.

**1. A syntax error makes its harness exit non-zero** — appended `export const BROKEN = (((;` to the module under test and ran its harness. Four different harnesses, chosen because their preambles differ (`peer` reads `node:fs/promises` too, `compress` uses a `path`/`here` defined outside the block):

| harness | broken module | before | after |
|---|---|---|---|
| `transfer.check.mjs` | `transfer.ts` | exit 0, SKIP | **exit 1**, real esbuild error |
| `compress.check.mjs` | `compress.ts` | exit 0, SKIP | **exit 1** |
| `peer.check.mjs` | `peer.ts` | exit 0, SKIP | **exit 1** |
| `pieceManifest.check.mjs` | `pieceManifest.ts` | exit 0, SKIP | **exit 1** |

**2. A genuinely missing esbuild still skips with exit 0** — I forced the real path rather than reasoning about it: moved `web/node_modules/esbuild` aside, confirmed `import("esbuild")` actually fails with `ERR_MODULE_NOT_FOUND`, then ran the harness.

```
SKIP: esbuild not available to transpile TS for this check — Cannot find package 'esbuild' imported from .../transfer.check.mjs
exit 0
```

Symlink restored afterwards and `check:engine` re-run to confirm the tree was left healthy.

**3. All 15 harnesses pass unchanged** — `pnpm --filter @warp/web check:engine` → `run-checks: all 15 engine harnesses passed`, exit 0 measured without a pipe.

Also `typecheck` clean and `lint` 0 errors (7 warnings, all pre-existing on `main` — I ran lint on an untouched `main` to confirm the same 7 in the same two files, `useWarpTransfer.ts` and `primitives.tsx`, neither touched here).

## Note for after this lands

Open PR #219 adds a 16th harness (`roomCode.check.mjs`). If it carries the same preamble it'll want the same treatment — different file, so no conflict with this PR either way.

## Checklist

- [x] `pnpm lint && pnpm typecheck` pass locally
- [x] Engine harnesses pass, and now actually fail when they should
- No UI change, so the mobile-width and design-token lines don't apply

### Hard constraints

- [x] No new recurring-cost infrastructure
- [x] Still STUN-only
- [x] Signaling server still never reads or understands file contents
- [x] `SEND_HIGH_WATER` untouched
- [x] Transient drops still recover; keepalive untouched

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR narrows optional-esbuild error handling in 13 engine harnesses so transpilation and generated-module import failures propagate instead of being reported as successful skips.
- Keeps the existing exit-zero behavior when importing esbuild fails.
- Moves each esbuild build and data-URL module import outside the catch.
- Leaves harness assertions and production behavior unchanged.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no actionable regressions identified in the changed harness preambles.

The changes consistently move esbuild builds and generated-module imports beyond the successful-skip catch, causing the targeted failures to propagate while preserving the established missing-esbuild behavior.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/src/lib/warp/compress.check.mjs | Narrows the catch to loading esbuild while preserving shared path setup and allowing compilation or generated-module failures to propagate. |
| web/src/lib/warp/peer.check.mjs | Moves Node built-in loading, peer bundling, and bundled-module import outside the optional-esbuild catch without changing assertions. |
| web/src/lib/warp/pieceManifest.check.mjs | Ensures failures while bundling or importing pieceManifest.ts terminate the harness rather than producing a successful skip. |
| web/src/lib/warp/transfer.check.mjs | Restricts successful skipping to esbuild import failures and lets transfer.ts build or import errors fail the harness. |
| web/src/lib/warp/zipDownload.check.mjs | Preserves the existing transpilation flow while exposing build and generated-module import failures to the check runner. |

<sub>Reviews (1): Last reviewed commit: ["fix(checks): let build and import errors..."](https://github.com/ishannaik/warp/commit/7b73429f1ec4bfabbb0569711edc45ffeffc6027) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51401967)</sub>

<!-- /greptile_comment -->