### PR TITLE
perf: preconnect to signaling origin

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -58,6 +58,8 @@
       }
     </script>
 
+    <!-- Self-hosters: update this origin when VITE_SIGNALING_URL points elsewhere. -->
+    <link rel="preconnect" href="https://warp-signaling.ishannaik7.workers.dev" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link


### PR DESCRIPTION
Closes #86

Adds a preconnect hint for Warp's default signaling origin and a short self-hosting note in `web/index.html`.

- 1 file changed
- no behavior change
- no new dependency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved initial connection readiness by preconnecting to the configured signaling server.
  * Added guidance for self-hosted deployments using a different signaling URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds a browser preconnect hint for Warp’s default signaling service to reduce connection setup latency.
- Documents that self-hosted deployments using another signaling URL must update the hint.
- Introduces no dependencies or runtime application-code changes.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The hint targets the existing default signaling origin, and the adjacent comment accurately documents the required self-hosting adjustment.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/index.html | Adds a valid preconnect hint and clearly documents the manual adjustment required for custom signaling origins. |

<sub>Reviews (1): Last reviewed commit: ["perf: preconnect to signaling origin"](https://github.com/ishannaik/warp/commit/88f96cbab44c614f474cabace0021250b9a23a75) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51402880)</sub>

<!-- /greptile_comment -->