### PR TITLE
fix: show full filenames on hover

### DIFF
--- a/web/src/transfer/SessionView.tsx
+++ b/web/src/transfer/SessionView.tsx
@@ -177,6 +177,7 @@ const ItemRow = memo(function ItemRow({
 
         <span style={{ minWidth: 0, flex: 1 }}>
           <span
+            title={isText ? undefined : item.name}
             style={{
               display: "block",
               fontSize: "14px",
@@ -623,6 +624,7 @@ function PendingTray({
           >
             <Thumb item={{ mime: p.file.type, kind: "file" }} size={isMobile ? 34 : 38} />
             <span
+              title={p.file.name}
               style={{
                 flex: 1,
                 minWidth: 0,
@@ -913,6 +915,7 @@ export function AcceptModal({
             >
               <Thumb item={it} size={isMobile ? 34 : 38} />
               <span
+                title={it.name}
                 style={{
                   flex: 1,
                   minWidth: 0,

--- a/web/src/transfer/TransferFlow.tsx
+++ b/web/src/transfer/TransferFlow.tsx
@@ -450,6 +450,7 @@ function QueueList({
               <div style={{ width: "8px", height: "8px", background: "var(--acc)" }} />
             </div>
             <span
+              title={q.file.name}
               style={{
                 fontSize: "14px",
                 fontWeight: 500,


### PR DESCRIPTION
Closes #85

Adds native `title` attributes to ellipsized file names in the send queue, pending/session tray, transfer tray rows, and accept-offer manifest.

- native browser hover affordance only
- no custom tooltip component
- no layout or transfer-behavior changes

Local build was not run from this environment; CI can validate the web build.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds native browser tooltips so truncated filenames can be viewed in full on hover.

- Adds filename `title` attributes to transfer rows, pending-file rows, and incoming manifests.
- Adds the same hover affordance to the shared editable transfer queue.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The changes only expose existing filename strings through native title attributes on the same elements that already render those names, without affecting layout, state, or transfer logic.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/src/transfer/SessionView.tsx | Adds native filename hover text to transfer, pending, and incoming-manifest rows without changing transfer behavior. |
| web/src/transfer/TransferFlow.tsx | Adds native filename hover text to queued-file rows without changing queue behavior. |

<sub>Reviews (1): Last reviewed commit: ["fix: expose full filenames on hover"](https://github.com/ishannaik/warp/commit/45a4156442da9c8be926ef2662724ab9c33f5950) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51462455)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility & Usability**
  * Added native tooltips showing full file and item names when displayed text is truncated.
  * Tooltips are available in transfer rows, pending-file trays, accept dialogs, and queued-file lists.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->