### PR TITLE
feat: tab-title progress + warn-before-close mid-transfer (#15, #14)

### DIFF
--- a/web/src/lib/useTransferTitle.ts
+++ b/web/src/lib/useTransferTitle.ts
@@ -1,0 +1,60 @@
+import { useEffect, useRef } from "react";
+import type { TransferItem } from "./warp/transfer";
+
+/**
+ * #15 — Show live transfer progress in the tab title.
+ *
+ * While any file transfer is in flight, `document.title` becomes
+ * `↑ 42% · Warp` (arrow = direction: ↑ sending, ↓ receiving, ⇅ both), so a
+ * user who switched tabs gets glanceable progress without tabbing back.
+ *
+ * - Reads the LATEST items from a ref inside a 1s interval; the effect itself
+ *   depends only on the inactive→active flip, so it never re-runs on progress
+ *   ticks (and never clobbers the route title with a stale capture).
+ * - Captures the pre-transfer title when the transfer starts and restores it
+ *   when the last item finishes/errors or the component unmounts, so it plays
+ *   nicely with `useDocumentSeo`'s static per-route title.
+ * - Throttled to ~1 write/second (title churn hammers some browsers).
+ */
+export function useTransferTitle(items: TransferItem[]): void {
+  const itemsRef = useRef(items);
+  itemsRef.current = items;
+  const lastWritten = useRef(0);
+
+  const hasActive = items.some(
+    (t) => t.kind === "file" && (t.status === "transferring" || t.status === "reconnecting" || t.status === "paused"),
+  );
+
+  useEffect(() => {
+    if (!hasActive) return;
+    const prev = document.title;
+
+    const write = () => {
+      const now = Date.now();
+      if (now - lastWritten.current < 1000) return;
+      lastWritten.current = now;
+
+      const active = itemsRef.current.filter(
+        (t) => t.kind === "file" && (t.status === "transferring" || t.status === "reconnecting" || t.status === "paused"),
+      );
+      if (!active.length) return;
+
+      const sending = active.some((t) => t.direction === "send");
+      const receiving = active.some((t) => t.direction === "receive");
+      const arrow = sending && receiving ? "⇅" : sending ? "↑" : "↓";
+
+      const total = active.reduce((s, t) => s + t.size, 0);
+      const done = active.reduce((s, t) => s + t.transferred, 0);
+      const pct = total > 0 ? Math.round((done / total) * 100) : 0;
+
+      document.title = `${arrow} ${pct}% · Warp`;
+    };
+
+    write();
+    const id = setInterval(write, 1000);
+    return () => {
+      clearInterval(id);
+      document.title = prev;
+    };
+  }, [hasActive]);
+}

--- a/web/src/lib/warp/peer.check.mjs
+++ b/web/src/lib/warp/peer.check.mjs
@@ -1088,6 +1088,206 @@ bigFile.slice = Blob.prototype.slice;
   await lSendP;
 }
 
+// --- pause / resume (#247) ---------------------------------------------------
+// Pause stops the pump WITHOUT file-end so the receiver's sink stays healthy at
+// the durable offset. Resume is a re-offer with resume offsets — same path as a
+// network-drop recovery, triggered on purpose.
+{
+  // Shared durable sink across begin() calls (mirrors the hook's registry): a
+  // pause must NOT end/abort it, and a resumed file-begin must append onto it.
+  let heldSink = null;
+  const makeHeldSink = () => {
+    const chunks = [];
+    let n = 0;
+    return {
+      get bytesWritten() {
+        return n;
+      },
+      get failed() {
+        return false;
+      },
+      append(buf) {
+        chunks.push(new Uint8Array(buf));
+        n += buf.byteLength;
+      },
+      async quiesce() {},
+      async finalize() {
+        const out = new Uint8Array(n);
+        let off = 0;
+        for (const c of chunks) {
+          out.set(c, off);
+          off += c.byteLength;
+        }
+        return new Blob([out]);
+      },
+      async abort() {
+        chunks.length = 0;
+        n = 0;
+      },
+    };
+  };
+  const pauseHost = {
+    begin() {
+      if (!heldSink) heldSink = makeHeldSink();
+      return heldSink;
+    },
+    get() {
+      return heldSink;
+    },
+    savedName() {
+      return undefined;
+    },
+    end() {
+      /* keep the sink across pause — host.end would drop the partial */
+    },
+  };
+
+  const savedPc = globalThis.RTCPeerConnection;
+  globalThis.RTCPeerConnection = BackpressurePC;
+  const pSender = new WarpPeer(sig, "pause-remote", true);
+  globalThis.RTCPeerConnection = savedPc;
+  const pReceiver = new WarpPeer(sig, "pause-local", false, pauseHost);
+  const pSenderCh = pSender.pc.localChannel;
+  const pReceiverCh = new FakeChannel();
+  pSenderCh.peer = pReceiverCh;
+  pReceiverCh.peer = pSenderCh;
+  pReceiver.pc.dispatchEvent(Object.assign(new Event("datachannel"), { channel: pReceiverCh }));
+
+  // Spy: count file-end / cancel frames so pause must send neither.
+  let fileEnds = 0;
+  let cancels = 0;
+  const pRawSend = pSenderCh.send.bind(pSenderCh);
+  pSenderCh.send = (d) => {
+    if (typeof d === "string") {
+      const msg = JSON.parse(d);
+      if (msg.t === "file-end") fileEnds += 1;
+      if (msg.t === "cancel") cancels += 1;
+    }
+    return pRawSend(d);
+  };
+
+  // Use the >high-water big file so the pump parks; we drain just enough for a
+  // partial durable write, then pause before the rest can finish.
+  const pauseFile = new Blob([bigBytes], { type: "application/octet-stream" });
+  pauseFile.name = "pause.bin";
+  pauseFile.slice = Blob.prototype.slice;
+
+  const pOfferSeen = waitFor(pReceiver, "incoming-offer");
+  const pSendP = pSender.offerFiles([pauseFile]);
+  const pOffer = await pOfferSeen;
+  const livePauseId = pOffer.items[0].id;
+  pReceiver.acceptOffer(pOffer.batchId);
+
+  // Wait until the send queue is full (pump parked mid-file). Bytes already
+  // delivered to the receiver are durable in heldSink — that is the pause offset.
+  await waitForCondition(
+    () => pSenderCh.bufferedAmount + 256 * 1024 > SEND_HIGH_WATER,
+    "pump parked before pause",
+  );
+  await waitForCondition(
+    () => (heldSink?.bytesWritten ?? 0) > 256 * 1024,
+    "receiver has a durable partial before pause",
+  );
+
+  const pausedAt = heldSink.bytesWritten;
+  assert.ok(pausedAt > 0 && pausedAt < BIG_N, "pause lands mid-file");
+
+  sigSent.length = 0;
+  pSender.pause(livePauseId);
+  assert.equal(sigSent.length, 1, "pause() emits one out-of-band signaling pause");
+  assert.deepEqual(sigSent[0].data, { kind: "pause", id: livePauseId }, "signaling pause carries kind:'pause' + id");
+
+  // Wake the pump so it observes pausedIds on the chunk boundary after drain.
+  for (let i = 0; i < 10; i += 1) {
+    pSenderCh.bufferedAmount = Math.max(0, pSenderCh.bufferedAmount - 2 * 1024 * 1024);
+    pSenderCh.dispatchEvent(new Event("bufferedamountlow"));
+    await new Promise((res) => setImmediate(res));
+  }
+  await pSendP;
+  await new Promise((r) => setTimeout(r, 30));
+  const durableAtPause = heldSink.bytesWritten;
+
+  assert.equal(fileEnds, 0, "pause stops the pump with no file-end");
+  assert.equal(cancels, 0, "pause must not send cancel (that would poison the sink path)");
+  assert.ok(
+    durableAtPause >= pausedAt && durableAtPause < BIG_N,
+    "sink retains the acknowledged mid-file bytes (no reset, no completion)",
+  );
+
+  // Resume: re-offer the same file; accept with the durable offset so the sender
+  // streams only the tail onto the SAME healthy sink.
+  const resumeOfferSeen = waitFor(pReceiver, "incoming-offer");
+  const resumeSendP = pSender.offerFiles([pauseFile]);
+  const resumeOffer = await resumeOfferSeen;
+  const resumeId = resumeOffer.items[0].id;
+  assert.equal(
+    resumeOffer.items[0].resumeToken,
+    pOffer.items[0].resumeToken,
+    "resume re-offers with the SAME resumeToken",
+  );
+
+  const gotResumed = waitFor(pReceiver, "file-received");
+  pReceiver.acceptOffer(resumeOffer.batchId, undefined, { [resumeId]: heldSink.bytesWritten });
+
+  // Drain the backpressure channel so the resume pump can finish.
+  const drainResume = setInterval(() => {
+    if (pSenderCh.bufferedAmount > 0) {
+      pSenderCh.bufferedAmount = Math.max(0, pSenderCh.bufferedAmount - 2 * 1024 * 1024);
+      pSenderCh.dispatchEvent(new Event("bufferedamountlow"));
+    }
+  }, 5);
+
+  const resumed = await Promise.race([
+    gotResumed,
+    new Promise((_, rej) => setTimeout(() => rej(new Error("resume after pause hung")), 8000)),
+  ]);
+  clearInterval(drainResume);
+  await resumeSendP;
+
+  assert.equal(fileEnds, 1, "resume completes with exactly one file-end");
+  const out = new Uint8Array(await resumed.blob.arrayBuffer());
+  assert.equal(out.byteLength, BIG_N, "resumed file is full length");
+  assert.deepEqual(out, bigBytes, "resumed file is byte-identical to the source");
+}
+
+// Pause while the pump is parked in waitForDrain: must take effect on the next
+// chunk boundary (after drain returns), not mid-chunk / inside the wait.
+{
+  const { s, r, sCh } = makeBackpressurePair();
+  const drainFile = new Blob([bigBytes], { type: "application/octet-stream" });
+  drainFile.name = "drain-pause.bin";
+  drainFile.slice = Blob.prototype.slice;
+
+  let ends = 0;
+  const raw = sCh.send.bind(sCh);
+  sCh.send = (d) => {
+    if (typeof d === "string" && JSON.parse(d).t === "file-end") ends += 1;
+    return raw(d);
+  };
+
+  const offerSeen = waitFor(r, "incoming-offer");
+  const sendP = s.offerFiles([drainFile]);
+  const off = await offerSeen;
+  r.acceptOffer(off.batchId);
+  const id = off.items[0].id;
+
+  // Wait until bufferedAmount is above high-water (pump parked in waitForDrain).
+  await waitForCondition(
+    () => sCh.bufferedAmount + 256 * 1024 > SEND_HIGH_WATER,
+    "pump parked in waitForDrain",
+  );
+  s.pause(id);
+
+  // Drain enough for the pump to wake, observe pause, and exit without file-end.
+  for (let i = 0; i < 20; i += 1) {
+    sCh.bufferedAmount = Math.max(0, sCh.bufferedAmount - 2 * 1024 * 1024);
+    sCh.dispatchEvent(new Event("bufferedamountlow"));
+    await new Promise((res) => setImmediate(res));
+  }
+  await sendP;
+  assert.equal(ends, 0, "pause during drain wait exits with no file-end");
+}
+
 console.log(
-  "OK: offer/accept stream + text size cap + decline gating + disk-stream + instant-cancel + pending-offer channel-close rejection + send-pump backpressure + negotiated compression + piece-manifest targeted re-request + unanswerable-piece liveness (#137) + resumed-tail piece verification (#171) passed",
+  "OK: offer/accept stream + text size cap + decline gating + disk-stream + instant-cancel + pending-offer channel-close rejection + send-pump backpressure + negotiated compression + piece-manifest targeted re-request + unanswerable-piece liveness (#137) + resumed-tail piece verification (#171) + pause/resume (#247) passed",
 );

--- a/web/src/lib/warp/peer.ts
+++ b/web/src/lib/warp/peer.ts
@@ -172,6 +172,8 @@ export interface PeerEvents {
   declined: (info: { batchId: string }) => void;
   /** A file in flight was cancelled by either side. */
   cancelled: (info: { id: string }) => void;
+  /** The other side asked us to resume a paused file (re-offer if we are the sender). */
+  "resume-requested": (info: { id: string }) => void;
   /** SHA-256 hex digest of a completed file's session bytes. Emitted once per
    *  successfully-transferred file (both send and receive) that hashed a whole
    *  session — resumed transfers (startOffset > 0 on send, resume offset > 0 on
@@ -331,6 +333,7 @@ export class WarpPeer {
     "text-received": new Set(),
     declined: new Set(),
     cancelled: new Set(),
+    "resume-requested": new Set(),
     "hash-computed": new Set(),
     error: new Set(),
   };
@@ -364,6 +367,9 @@ export class WarpPeer {
 
   /** File ids the local side asked to cancel, so we drop their remaining chunks. */
   private cancelledIds = new Set<string>();
+
+  /** File ids paused mid-send: the pump exits without file-end so the sink stays open. */
+  private pausedIds = new Set<string>();
 
   /** Files we sent WITH a piece manifest (#137), keyed by file id, so a receiver's
    *  `piece-request` can re-read and re-send just that piece. Holds lazy File
@@ -515,6 +521,20 @@ export class WarpPeer {
       // this beats the in-band {t:"cancel"} that's stuck behind the byte backlog.
       // Idempotent, so the later in-band dup is a harmless no-op.
       this.applyCancel(data.id);
+      return;
+    }
+
+    if (data.kind === "pause") {
+      // Out-of-band pause: stop the pump / mark paused without poisoning the sink.
+      // Beats the in-band {t:"pause"} stuck behind the byte backlog.
+      this.applyPause(data.id);
+      return;
+    }
+
+    if (data.kind === "resume") {
+      // Out-of-band resume request: the hook clears pausedKeys and re-offers if
+      // this side holds the File. No in-band twin — the pump is already stopped.
+      this.emit("resume-requested", { id: data.id });
       return;
     }
 
@@ -675,6 +695,10 @@ export class WarpPeer {
           this.cancelledIds.delete(id);
           continue; // cancelled before it started; status already set by cancel()
         }
+        if (this.pausedIds.has(id)) {
+          this.pausedIds.delete(id);
+          continue; // paused before it started; status already set by pause()
+        }
 
         // Resume offset the receiver asked for, validated (Fable L1). A garbage
         // or >size offset falls back to 0 (full restart); the echoed file-begin
@@ -722,8 +746,13 @@ export class WarpPeer {
         this.send(ch, { t: "file-begin", id, offset, ...(codec ? { codec } : {}), ...(pieces ? { pieces } : {}) });
         const finishedClean = await this.streamFile(ch, file, item, offset, codec);
         if (!finishedClean) {
-          // Cancelled mid-flight: tell the receiver and stop this file.
           this.manifestSends.delete(id);
+          // Pause leaves the receiver's sink open — no file-end, no cancel.
+          // Cancel (or a remote cancel that raced the pump) still needs the
+          // in-band cancel so a receiver that missed the OOB frame tears down.
+          // Re-read from the map: streamFile / applyPause mutate status on the
+          // shared object, but TS still sees the pre-stream narrowed union.
+          if (this.items.get(id)?.status === "paused") continue;
           this.send(ch, { t: "cancel", id });
           continue;
         }
@@ -857,6 +886,35 @@ export class WarpPeer {
   }
 
   /**
+   * Pause a file in flight from either side. The sender's pump exits WITHOUT
+   * sending file-end, so the receiver's durable sink stays open at the last
+   * acknowledged offset. Resume is a re-offer with the same resumeToken.
+   *
+   * Announced two ways, mirroring cancel:
+   *   1. OUT-OF-BAND over signaling — beats the data-channel byte backlog.
+   *   2. IN-BAND over the data channel — survives a dropped signaling socket.
+   * Both are idempotent (see applyPause).
+   *
+   * Unlike cancel, this does NOT abort or end the receive sink.
+   */
+  pause(id: string): void {
+    if (!this.applyPause(id)) return;
+
+    if (this.remoteId) this.signaling.signal(this.remoteId, { kind: "pause", id });
+    const ch = this.channel;
+    if (ch && ch.readyState === "open") this.send(ch, { t: "pause", id });
+  }
+
+  /**
+   * Ask the other side to resume a paused file (clear their pausedKeys / re-offer
+   * if they hold the File). Out-of-band only — the pump is already stopped, so
+   * there is no byte backlog to jump.
+   */
+  requestResume(id: string): void {
+    if (this.remoteId) this.signaling.signal(this.remoteId, { kind: "resume", id });
+  }
+
+  /**
    * Idempotently mark a file cancelled and abort any in-flight send/receive for
    * it. Returns false (a no-op) if the item is unknown or already done/cancelled,
    * so a redundant in-band + out-of-band cancel is safe. Emits "cancelled" exactly
@@ -867,6 +925,7 @@ export class WarpPeer {
     if (!item || item.status === "done" || item.status === "cancelled") return false;
 
     this.cancelledIds.add(id); // streamFile checks this per chunk to abort sends
+    this.pausedIds.delete(id); // cancel wins over a prior pause
     this.manifestSends.delete(id); // no piece re-requests for a cancelled file (#137)
     this.markStatus(id, "cancelled");
 
@@ -886,6 +945,41 @@ export class WarpPeer {
   }
 
   /**
+   * Idempotently mark a file paused. Stops the send pump (via pausedIds) and
+   * detaches the receive path WITHOUT aborting or ending the sink — that is the
+   * whole difference from cancel, and what lets resume continue from the durable
+   * offset. Returns false if unknown or already terminal/paused.
+   */
+  private applyPause(id: string): boolean {
+    const item = this.items.get(id);
+    if (
+      !item ||
+      item.status === "done" ||
+      item.status === "cancelled" ||
+      item.status === "paused" ||
+      item.status === "declined" ||
+      item.status === "error"
+    ) {
+      return false;
+    }
+
+    this.pausedIds.add(id); // streamFile checks this per chunk to exit without file-end
+    this.markStatus(id, "paused");
+
+    // Detach the receive path so late chunks are dropped (sender will resend
+    // from the durable offset on resume). Do NOT abort the sink or host.end —
+    // the partial must stay healthy for the auto-resume path.
+    if (this.incoming && this.incoming.item.id === id) {
+      const inc = this.incoming;
+      inc.cancelled = true;
+      this.incoming = null;
+      inc.hash?.dispose();
+    }
+
+    return true;
+  }
+
+  /**
    * The per-message send size for this connection: as large as the negotiated
    * SCTP limit allows, capped at our 256 KiB target and floored at 16 KiB.
    * pc.sctp / maxMessageSize is undefined until the transport is up (and absent
@@ -899,8 +993,9 @@ export class WarpPeer {
   }
 
   /**
-   * Pump one file's bytes through the channel. Returns false if cancelled
-   * mid-flight.
+   * Pump one file's bytes through the channel. Returns false if cancelled or
+   * paused mid-flight (caller distinguishes via item.status — pause must not
+   * send cancel/file-end).
    *
    * Speed: read the file in large READ_BLOCK (~4 MiB) gulps via
    * blob.arrayBuffer(), then ship each block as a run of sendChunk-sized
@@ -938,6 +1033,10 @@ export class WarpPeer {
           this.cancelledIds.delete(item.id);
           return false;
         }
+        if (this.pausedIds.has(item.id)) {
+          this.pausedIds.delete(item.id);
+          return false;
+        }
 
         // Read one large block, then slice it into sendChunk-sized SCTP messages.
         const block = await file.slice(offset, offset + READ_BLOCK).arrayBuffer();
@@ -948,12 +1047,26 @@ export class WarpPeer {
             this.cancelledIds.delete(item.id);
             return false;
           }
+          if (this.pausedIds.has(item.id)) {
+            this.pausedIds.delete(item.id);
+            return false;
+          }
           // Backpressure: wait until the send buffer drains below the high-water
           // mark. Counts the chunk we're ABOUT to send, so we can never push
           // bufferedAmount toward the browser's hard cap and blow up send().
           while (ch.bufferedAmount + sendChunk > SEND_HIGH_WATER) {
             await this.waitForDrain(ch);
             if (ch.readyState !== "open") throw new Error("channel-closed-mid-send");
+            // Pause/cancel that landed while parked takes effect on this chunk
+            // boundary — never mid-send, and not inside waitForDrain itself.
+            if (this.cancelledIds.has(item.id)) {
+              this.cancelledIds.delete(item.id);
+              return false;
+            }
+            if (this.pausedIds.has(item.id)) {
+              this.pausedIds.delete(item.id);
+              return false;
+            }
           }
           if (ch.readyState !== "open") throw new Error("channel-closed-mid-send");
 
@@ -1128,6 +1241,11 @@ export class WarpPeer {
         // cancelled. Idempotent — a no-op if the out-of-band signaling cancel
         // already landed (or vice-versa).
         this.applyCancel(msg.id);
+        break;
+      }
+      case "pause": {
+        // Remote paused this file (in-band path). Leave the sink alone.
+        this.applyPause(msg.id);
         break;
       }
       case "text": {

--- a/web/src/lib/warp/signaling.ts
+++ b/web/src/lib/warp/signaling.ts
@@ -42,7 +42,9 @@ export type SignalData =
   | { kind: "offer"; sdp: string }
   | { kind: "answer"; sdp: string }
   | { kind: "ice"; candidate: RTCIceCandidateInit }
-  | { kind: "cancel"; id: string };
+  | { kind: "cancel"; id: string }
+  | { kind: "pause"; id: string }
+  | { kind: "resume"; id: string };
 
 /** Messages we receive from the server, discriminated on `type`. */
 export type ServerMessage =

--- a/web/src/lib/warp/transfer.ts
+++ b/web/src/lib/warp/transfer.ts
@@ -100,6 +100,8 @@ export type ControlMessage =
   | { t: "piece"; id: string; index: number }
   /** Either side cancels a file in flight (sender stops; receiver discards partial). */
   | { t: "cancel"; id: string }
+  /** Either side pauses a file in flight (sender stops the pump; receiver keeps the sink). */
+  | { t: "pause"; id: string }
   /** A text snippet — shown directly in the other side's tray (no accept needed). */
   | { t: "text"; id: string; text: string };
 
@@ -114,6 +116,7 @@ export type TransferStatus =
   | "offered" // announced, awaiting accept (send) / awaiting bytes (receive)
   | "transferring" // bytes in flight
   | "reconnecting" // transport dropped mid-file; holding progress, will resume
+  | "paused" // held by the user; sink intact, will continue from the durable offset
   | "done" // fully transferred
   | "declined" // the receiver declined the batch
   | "cancelled" // cancelled mid-flight by either side

--- a/web/src/lib/warp/useWarpTransfer.check.mjs
+++ b/web/src/lib/warp/useWarpTransfer.check.mjs
@@ -41,6 +41,8 @@ class FakePeer {
     this.acceptTargets = [];
     this.declined = [];
     this.cancelled = [];
+    this.paused = [];
+    this.resumeRequested = [];
     this.resumes = [];
     this.closed = false;
     this._listeners = {};
@@ -68,6 +70,12 @@ class FakePeer {
   }
   cancel(id) {
     this.cancelled.push(id);
+  }
+  pause(id) {
+    this.paused.push(id);
+  }
+  requestResume(id) {
+    this.resumeRequested.push(id);
   }
   close() {
     this.closed = true;
@@ -363,6 +371,7 @@ assert(fsPickers.fileCalls === 0 && fsPickers.dirCalls === 0, "no picker is prom
 // inactive entry auto-accepts with the durable offset and NO modal.
 const receiveReg = new Map();
 const cancelledKeys = new Set();
+const pausedKeys = new Set();
 
 function fakeSink(bytes, failed = false) {
   return { bytesWritten: bytes, failed, async quiesce() {}, async abort() {} };
@@ -382,7 +391,8 @@ async function handleOffer(peerId, info) {
         !e.sink.failed &&
         !!it.resumeToken &&
         e.resumeToken === it.resumeToken &&
-        !cancelledKeys.has(it.key)
+        !cancelledKeys.has(it.key) &&
+        !pausedKeys.has(it.key)
       );
     });
   if (!allResumable) {
@@ -463,6 +473,73 @@ rp.accepted.length = 0;
 await handleOffer(rp.remoteId, { batchId: "re7", items: [{ id: "s1", key: "sick|8|7", size: 8, resumeToken: "tok-F" }] });
 assert(incoming && incoming.batchId === "re7", "a re-offer onto a POISONED sink surfaces the modal, not auto-resume");
 assert(rp.accepted.length === 0, "a poisoned-sink re-offer is NOT auto-accepted");
+
+// 6h. Pause/resume guard (#247): a paused key is NOT auto-resumed by an unrelated
+// reconnect; explicit resume clears the guard; cancel after pause poisons the sink.
+receiveReg.set("held.bin|20|3", {
+  key: "held.bin|20|3",
+  size: 20,
+  resumeToken: "tok-P",
+  sink: fakeSink(8),
+  active: false,
+  target: undefined,
+});
+pausedKeys.add("held.bin|20|3");
+incoming = null;
+rp.accepted.length = 0;
+await handleOffer(rp.remoteId, {
+  batchId: "re8",
+  items: [{ id: "p1", key: "held.bin|20|3", size: 20, resumeToken: "tok-P" }],
+});
+assert(incoming && incoming.batchId === "re8", "a paused key is not auto-resumed by an unrelated reconnect");
+assert(rp.accepted.length === 0, "paused-key re-offer is NOT auto-accepted");
+
+// Explicit resume clears the paused key — a following re-offer auto-resumes.
+pausedKeys.delete("held.bin|20|3");
+incoming = null;
+await handleOffer(rp.remoteId, {
+  batchId: "re9",
+  items: [{ id: "p2", key: "held.bin|20|3", size: 20, resumeToken: "tok-P" }],
+});
+assert(incoming === null, "explicit resume clears the paused key and auto-resumes");
+assert(rp.resumes.at(-1) && rp.resumes.at(-1)["p2"] === 8, "post-resume auto-accept reports the durable offset");
+
+// Cancel after pause poisons the sink; a later re-offer surfaces the modal.
+receiveReg.set("held.bin|20|3", {
+  key: "held.bin|20|3",
+  size: 20,
+  resumeToken: "tok-P",
+  sink: fakeSink(8),
+  active: false,
+  target: undefined,
+});
+pausedKeys.add("held.bin|20|3");
+// cancel(id) mirror: poison + drop entry + cancelledKeys (and clear pausedKeys)
+{
+  const key = "held.bin|20|3";
+  cancelledKeys.add(key);
+  pausedKeys.delete(key);
+  const e = receiveReg.get(key);
+  if (e) void e.sink.abort();
+  receiveReg.delete(key);
+}
+incoming = null;
+rp.accepted.length = 0;
+// Even if a stale entry were re-created with a healthy sink, cancelledKeys blocks resume:
+receiveReg.set("held.bin|20|3", {
+  key: "held.bin|20|3",
+  size: 20,
+  resumeToken: "tok-P",
+  sink: fakeSink(8),
+  active: false,
+  target: undefined,
+});
+await handleOffer(rp.remoteId, {
+  batchId: "re10",
+  items: [{ id: "p3", key: "held.bin|20|3", size: 20, resumeToken: "tok-P" }],
+});
+assert(incoming && incoming.batchId === "re10", "cancel after pause poisons the path — re-offer surfaces the modal");
+assert(rp.accepted.length === 0, "cancel-after-pause re-offer is NOT auto-accepted");
 
 // 7. Reload-resume (issue #36, extended to OPFS by #169): the registry is repopulated
 // from the durable ledger on mount, and the EXISTING auto-resume path then continues

--- a/web/src/lib/warp/useWarpTransfer.ts
+++ b/web/src/lib/warp/useWarpTransfer.ts
@@ -1194,6 +1194,24 @@ export function useWarpTransfer(joinCode?: string): UseWarpTransfer {
     };
   }, [transferring]);
 
+  // Warn before the tab closes while bytes are in flight — an accidental ⌘W
+  // or reload kills every in-flight transfer for all peers. Native
+  // beforeunload prompt only while something is transferring/reconnecting/
+  // paused; removed the moment nothing is (an always-on listener disables
+  // bfcache and is hostile). Mirrors the wake-lock effect's shape.
+  const inFlight = items.some(
+    (t) => t.status === "transferring" || t.status === "reconnecting" || t.status === "paused",
+  );
+  useEffect(() => {
+    if (!inFlight) return;
+    const handler = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      e.returnValue = "";
+    };
+    window.addEventListener("beforeunload", handler);
+    return () => window.removeEventListener("beforeunload", handler);
+  }, [inFlight]);
+
   // Prune abandoned staging (IDB rows + OPFS files) and stale reload-resume ledger
   // rows from crashed sessions once on mount (best-effort).
   useEffect(() => {

--- a/web/src/lib/warp/useWarpTransfer.ts
+++ b/web/src/lib/warp/useWarpTransfer.ts
@@ -179,6 +179,10 @@ export interface UseWarpTransfer {
   decline: () => void;
   /** Cancel an in-flight item (either direction) by id — routed to its peer. */
   cancel: (id: string) => void;
+  /** Pause an in-flight item — sink stays healthy; resume continues from the durable offset. */
+  pause: (id: string) => void;
+  /** Resume a paused item — re-offers with the same resumeToken (or asks the sender to). */
+  resume: (id: string) => void;
   /** Save one received file's blob to disk via an anchor download. */
   downloadOne: (id: string) => void;
   /** Zip all received, done file-items into warp-files.zip and download it. */
@@ -298,6 +302,8 @@ export function useWarpTransfer(joinCode?: string): UseWarpTransfer {
   const receiveRegRef = useRef<Map<string, RxEntry>>(new Map());
   /** Keys the user explicitly cancelled — a re-offer of these must NOT auto-resume. */
   const cancelledKeysRef = useRef<Set<string>>(new Set());
+  /** Keys the user paused — skipped by auto-resume until an explicit resume() clears them. */
+  const pausedKeysRef = useRef<Set<string>>(new Set());
   /** Receive item id -> file key, so cancel(id) can find & poison the right entry. */
   const rxIdKeyRef = useRef<Map<string, string>>(new Map());
   /** Ref mirrors so long-lived peer event listeners never read stale state. */
@@ -363,6 +369,8 @@ export function useWarpTransfer(joinCode?: string): UseWarpTransfer {
   /** Salvage-and-rebuild for a dead peer; assigned below (breaks the
    *  bindPeer <-> salvagePeer <-> addInitiator callback cycle). */
   const salvageRef = useRef<(peerId: string) => void>(() => {});
+  /** Late-bound resume so bindPeer's resume-requested listener stays stable. */
+  const resumeRef = useRef<(id: string) => void>(() => {});
   /** Late-bound self-reference so connect's own handlers can re-connect. */
   const connectRef = useRef<(room?: string) => void>(() => {});
 
@@ -434,7 +442,8 @@ export function useWarpTransfer(joinCode?: string): UseWarpTransfer {
             !e.sink.failed &&
             !!it.resumeToken &&
             e.resumeToken === it.resumeToken &&
-            !cancelledKeysRef.current.has(it.key!)
+            !cancelledKeysRef.current.has(it.key!) &&
+            !pausedKeysRef.current.has(it.key!)
           );
         });
 
@@ -497,6 +506,17 @@ export function useWarpTransfer(joinCode?: string): UseWarpTransfer {
       // device it belongs to so the UI can tag tray rows / route cancels.
       peer.on("transfer", (item) => {
         upsertItem({ ...item, peerId });
+        // A pause (local or remote) must park the durable entry inactive and
+        // remember the key so an unrelated reconnect does not auto-resume.
+        // Unlike cancel, the sink stays healthy.
+        if (item.status === "paused" && item.direction === "receive") {
+          const key = rxIdKeyRef.current.get(item.id);
+          if (key) {
+            pausedKeysRef.current.add(key);
+            const e = receiveRegRef.current.get(key);
+            if (e) e.active = false;
+          }
+        }
         // Reload-resume (#36): persist a resumable receive's DURABLE offset to the
         // ledger. For a receive, item.transferred IS sink.bytesWritten (durable), and
         // the peer throttles these emits to ~1% deltas, so this is a cheap upsert on
@@ -538,6 +558,10 @@ export function useWarpTransfer(joinCode?: string): UseWarpTransfer {
       peer.on("text-received", () => {});
       peer.on("declined", () => {});
       peer.on("cancelled", () => {});
+
+      peer.on("resume-requested", ({ id }) => {
+        resumeRef.current(id);
+      });
 
       peer.on("error", (kind) => {
         // A mid-session transport death is salvageable: rebuild the link and
@@ -717,7 +741,8 @@ export function useWarpTransfer(joinCode?: string): UseWarpTransfer {
           t.kind === "file" &&
           t.status !== "done" &&
           t.status !== "declined" &&
-          t.status !== "cancelled",
+          t.status !== "cancelled" &&
+          t.status !== "paused", // user-held; wait for explicit resume()
       );
 
       // Sender side: put the Files behind unfinished sends back on the staging
@@ -983,6 +1008,7 @@ export function useWarpTransfer(joinCode?: string): UseWarpTransfer {
       const key = rxIdKeyRef.current.get(id);
       if (key) {
         cancelledKeysRef.current.add(key);
+        pausedKeysRef.current.delete(key); // cancel wins over pause
         const e = receiveRegRef.current.get(key);
         if (e) void e.sink.abort();
         receiveRegRef.current.delete(key);
@@ -1006,6 +1032,66 @@ export function useWarpTransfer(joinCode?: string): UseWarpTransfer {
     },
     [],
   );
+
+  const pause = useCallback((id: string) => {
+    // Do NOT poison the sink (that is cancel's job). The transfer handler adds
+    // the key to pausedKeysRef when status flips to paused.
+    const item = itemsRef.current.find((t) => t.id === id);
+    const peer = item?.peerId ? peersRef.current.get(item.peerId) : undefined;
+    if (peer) {
+      peer.pause(id);
+      return;
+    }
+    for (const p of peersRef.current.values()) p.pause(id);
+  }, []);
+
+  /** Re-offer a paused send item. `notifyPeer` asks the receiver to clear its
+   *  pausedKeys before the offer arrives; skip it when WE are answering their
+   *  resume-requested (otherwise the two sides ping-pong). */
+  const reofferPausedSend = useCallback((id: string, notifyPeer: boolean) => {
+    const item = itemsRef.current.find((t) => t.id === id);
+    if (!item || item.direction !== "send" || item.status !== "paused") return;
+    const peer = item.peerId ? peersRef.current.get(item.peerId) : undefined;
+    const pool = allFilesRef.current;
+    const i = pool.findIndex((f) => f.name === item.name && f.size === item.size);
+    if (i === -1 || !peer) return;
+    const file = pool[i];
+    setItems((prev) => prev.filter((t) => t.id !== id));
+    if (notifyPeer) peer.requestResume(id);
+    void peer.offerFiles([file]).catch(() => {
+      pendingFilesRef.current = [file];
+    });
+  }, []);
+
+  const resume = useCallback(
+    (id: string) => {
+      const item = itemsRef.current.find((t) => t.id === id);
+      if (!item || item.status !== "paused") return;
+
+      // Clear the auto-resume guard so a re-offer continues from the durable offset.
+      const key = rxIdKeyRef.current.get(id);
+      if (key) pausedKeysRef.current.delete(key);
+
+      if (item.direction === "send") {
+        reofferPausedSend(id, true);
+        return;
+      }
+
+      // Receive side: ask the sender to re-offer.
+      const peer = item.peerId ? peersRef.current.get(item.peerId) : undefined;
+      if (peer) peer.requestResume(id);
+      else for (const p of peersRef.current.values()) p.requestResume(id);
+    },
+    [reofferPausedSend],
+  );
+
+  // resume-requested from the other side: clear our guard, and re-offer if we
+  // hold the File. Do NOT echo requestResume — that would loop.
+  resumeRef.current = (id: string) => {
+    const key = rxIdKeyRef.current.get(id);
+    if (key) pausedKeysRef.current.delete(key);
+    reofferPausedSend(id, false);
+  };
 
   const downloadOne = useCallback(
     (id: string) => {
@@ -1258,6 +1344,8 @@ export function useWarpTransfer(joinCode?: string): UseWarpTransfer {
     accept,
     decline,
     cancel,
+    pause,
+    resume,
     downloadOne,
     downloadAll,
     retry,

--- a/web/src/nearby/NearbyDevices.tsx
+++ b/web/src/nearby/NearbyDevices.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import type { CSSProperties } from "react";
 import { navigate } from "../router";
 import { useIsMobile } from "../lib/useIsMobile";
+import { useTransferTitle } from "../lib/useTransferTitle";
 import { AcceptModal, SessionView } from "../transfer/SessionView";
 import { useNearbyTransfer, type NearbyDevice } from "./useNearbyTransfer";
 import type { DeviceType } from "../lib/warp/useNearby";
@@ -28,6 +29,9 @@ export default function NearbyDevices() {
   const isMobile = useIsMobile();
   const nearby = useNearbyTransfer();
   const { devices, crowded, deviceName, session, incoming, rename } = nearby;
+
+  // #15: live progress in the tab title while a nearby transfer is in flight.
+  useTransferTitle(session?.items ?? []);
 
   const [isEditing, setIsEditing] = useState(false);
   const [draftName, setDraftName] = useState(deviceName);

--- a/web/src/nearby/NearbyDevices.tsx
+++ b/web/src/nearby/NearbyDevices.tsx
@@ -283,6 +283,8 @@ export default function NearbyDevices() {
               onSendFiles={(files) => nearby.sendTo(session.peerId, files)}
               onSendText={nearby.sendText}
               onCancel={nearby.cancel}
+              onPause={nearby.pause}
+              onResume={nearby.resume}
               onDownloadOne={nearby.downloadOne}
               onDownloadAll={nearby.downloadAll}
               isMobile={isMobile}

--- a/web/src/nearby/useNearbyTransfer.ts
+++ b/web/src/nearby/useNearbyTransfer.ts
@@ -65,6 +65,10 @@ export interface UseNearbyTransfer {
   declineIncoming: () => void;
   /** Cancel an in-flight item (either direction). */
   cancel: (id: string) => void;
+  /** Pause an in-flight item (sink stays open). */
+  pause: (id: string) => void;
+  /** Resume a paused item. */
+  resume: (id: string) => void;
   /** Save one received file's blob via an anchor download. */
   downloadOne: (id: string) => void;
   /** Zip all received, done file-items into nearby-files.zip and download. */
@@ -109,6 +113,8 @@ export function useNearbyTransfer(): UseNearbyTransfer {
   const peerNameRef = useRef<string>("Device");
   /** Discovery id of the active session peer. */
   const peerIdRef = useRef<string>("");
+  /** Last files offered this session — resume re-offers from here. */
+  const lastFilesRef = useRef<File[]>([]);
 
   // ---- session-state plumbing ---------------------------------------------
 
@@ -149,6 +155,19 @@ export function useNearbyTransfer(): UseNearbyTransfer {
       peer.on("text-received", () => {});
       peer.on("declined", () => {});
       peer.on("cancelled", () => {});
+      peer.on("resume-requested", ({ id }) => {
+        const item = itemsRef.current.find((t) => t.id === id);
+        if (!item || item.direction !== "send" || item.status !== "paused") return;
+        const file = lastFilesRef.current.find((f) => f.name === item.name && f.size === item.size);
+        if (!file) return;
+        setSession((prev) => {
+          if (!prev) return prev;
+          const items = prev.items.filter((t) => t.id !== id);
+          itemsRef.current = items;
+          return { ...prev, items };
+        });
+        void peer.offerFiles([file]).catch(() => failSession(PEER_ERROR_COPY["channel-error"]));
+      });
       peer.on("error", (kind) => failSession(PEER_ERROR_COPY[kind] ?? "The transfer failed."));
     },
     [failSession, upsertItem],
@@ -226,6 +245,7 @@ export function useNearbyTransfer(): UseNearbyTransfer {
       }
       if (!peer) return;
       const activePeer = peer;
+      lastFilesRef.current = [...lastFilesRef.current, ...files];
 
       // Offer the files once the channel is open (offerFiles requires an open channel).
       const offer = () =>
@@ -256,6 +276,30 @@ export function useNearbyTransfer(): UseNearbyTransfer {
   const cancel = useCallback((id: string) => {
     peerRef.current?.cancel(id);
   }, []);
+
+  const pause = useCallback((id: string) => {
+    peerRef.current?.pause(id);
+  }, []);
+
+  const resume = useCallback((id: string) => {
+    const item = itemsRef.current.find((t) => t.id === id);
+    const peer = peerRef.current;
+    if (!item || item.status !== "paused" || !peer) return;
+    if (item.direction === "send") {
+      const file = lastFilesRef.current.find((f) => f.name === item.name && f.size === item.size);
+      if (!file) return;
+      setSession((prev) => {
+        if (!prev) return prev;
+        const items = prev.items.filter((t) => t.id !== id);
+        itemsRef.current = items;
+        return { ...prev, items };
+      });
+      peer.requestResume(id);
+      void peer.offerFiles([file]).catch(() => failSession(PEER_ERROR_COPY["channel-error"]));
+      return;
+    }
+    peer.requestResume(id);
+  }, [failSession]);
 
   const downloadOne = useCallback((id: string) => {
     const item = itemsRef.current.find((t) => t.id === id);
@@ -298,6 +342,8 @@ export function useNearbyTransfer(): UseNearbyTransfer {
       acceptIncoming,
       declineIncoming,
       cancel,
+      pause,
+      resume,
       downloadOne,
       downloadAll,
       rename,
@@ -315,6 +361,8 @@ export function useNearbyTransfer(): UseNearbyTransfer {
       acceptIncoming,
       declineIncoming,
       cancel,
+      pause,
+      resume,
       downloadOne,
       downloadAll,
       rename,

--- a/web/src/nearby/useNearbyTransfer.ts
+++ b/web/src/nearby/useNearbyTransfer.ts
@@ -329,6 +329,23 @@ export function useNearbyTransfer(): UseNearbyTransfer {
     setSession(null);
   }, []);
 
+  // #14: warn before the tab closes while bytes are in flight (LAN flow too).
+  // Native beforeunload prompt only while something is transferring/
+  // reconnecting/paused; removed the moment nothing is.
+  const sessionItems = session?.items ?? [];
+  const nearbyInFlight = sessionItems.some(
+    (t) => t.status === "transferring" || t.status === "reconnecting" || t.status === "paused",
+  );
+  useEffect(() => {
+    if (!nearbyInFlight) return;
+    const handler = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      e.returnValue = "";
+    };
+    window.addEventListener("beforeunload", handler);
+    return () => window.removeEventListener("beforeunload", handler);
+  }, [nearbyInFlight]);
+
   return useMemo(
     () => ({
       selfId,

--- a/web/src/transfer/SessionView.tsx
+++ b/web/src/transfer/SessionView.tsx
@@ -100,6 +100,7 @@ const STATUS_COPY: Record<TransferItem["status"], string> = {
   offered: "WAITING",
   transferring: "MOVING",
   reconnecting: "RESUMING",
+  paused: "PAUSED",
   done: "DONE",
   declined: "DECLINED",
   cancelled: "CANCELLED",
@@ -109,6 +110,7 @@ const STATUS_COPY: Record<TransferItem["status"], string> = {
 function statusColor(status: TransferItem["status"]): string {
   if (status === "done") return "var(--acc)";
   if (status === "transferring" || status === "reconnecting") return "var(--amb)";
+  if (status === "paused") return "#efe9da";
   if (status === "declined" || status === "cancelled" || status === "error") return "#6f6a5d";
   return "#908a7b";
 }
@@ -120,12 +122,16 @@ function statusColor(status: TransferItem["status"]): string {
 const ItemRow = memo(function ItemRow({
   item,
   onCancel,
+  onPause,
+  onResume,
   onDownload,
   isMobile,
   peerLabel,
 }: {
   item: TransferItem;
   onCancel: (id: string) => void;
+  onPause: (id: string) => void;
+  onResume: (id: string) => void;
   onDownload: (id: string) => void;
   isMobile: boolean;
   /** Which device this item is to/from — shown only in a multi-device room. */
@@ -136,7 +142,9 @@ const ItemRow = memo(function ItemRow({
   const col = statusColor(item.status);
   // "reconnecting" holds the bar at its last % and shows RESUMING; it's still an
   // active, cancellable transfer, so it renders like transferring but labeled.
+  // "paused" is user-held: same bar, not an error, with a resume affordance.
   const active = item.status === "transferring" || item.status === "reconnecting";
+  const paused = item.status === "paused";
   const reconnecting = item.status === "reconnecting";
   const isText = item.kind === "text";
   // Items streamed straight to disk have no in-memory blob — they're already
@@ -218,18 +226,41 @@ const ItemRow = memo(function ItemRow({
           </span>
         </span>
 
-        {/* row actions */}
-        <span style={{ display: "flex", alignItems: "center", gap: "8px", flexShrink: 0 }}>
-          {active && (
-            <button
-              type="button"
-              className="warp-rowbtn"
-              onClick={() => onCancel(item.id)}
-              aria-label="Cancel transfer"
-              style={iconBtn}
+        {/* row actions — at 360px a two-button group replaces the single cancel
+            affordance; never a third control on the same line */}
+        <span style={{ display: "flex", alignItems: "center", gap: "6px", flexShrink: 0 }}>
+          {(active || paused) && (
+            <span
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 0,
+                border: `1px solid ${HAIRLINE}`,
+              }}
             >
-              ✕
-            </button>
+              <button
+                type="button"
+                className="warp-rowbtn"
+                onClick={() => (paused ? onResume(item.id) : onPause(item.id))}
+                aria-label={paused ? "Resume transfer" : "Pause transfer"}
+                style={{ ...iconBtn, border: "none", width: isMobile ? "28px" : "30px" }}
+              >
+                {paused ? "▶" : "Ⅱ"}
+              </button>
+              <span
+                aria-hidden
+                style={{ width: "1px", alignSelf: "stretch", background: HAIRLINE }}
+              />
+              <button
+                type="button"
+                className="warp-rowbtn"
+                onClick={() => onCancel(item.id)}
+                aria-label="Cancel transfer"
+                style={{ ...iconBtn, border: "none", width: isMobile ? "28px" : "30px" }}
+              >
+                ✕
+              </button>
+            </span>
           )}
           {canDownload && (
             <button
@@ -318,38 +349,37 @@ const ItemRow = memo(function ItemRow({
         </div>
       )}
 
-      {/* progress bar while transferring */}
-      {active && (
+      {/* progress bar while transferring or paused (held % — not an error) */}
+      {(active || paused) && (
         <div style={{ display: "flex", alignItems: "center", gap: "10px" }}>
-          <span
+          <div
             style={{
               flex: 1,
-              height: "6px",
-              background: "rgba(239,233,218,.09)",
+              height: "3px",
+              background: "rgba(239,233,218,.08)",
               overflow: "hidden",
             }}
           >
-            <span
+            <div
               style={{
-                display: "block",
                 height: "100%",
                 width: `${item.progress}%`,
-                background: col,
-                transition: "width .12s linear",
+                background: paused ? "#efe9da" : reconnecting ? "var(--amb)" : "var(--acc)",
+                transition: "width .2s linear",
               }}
             />
-          </span>
+          </div>
           <span
             style={{
               fontFamily: MONO,
               fontSize: "10.5px",
-              color: reconnecting ? "var(--amb)" : "#a8a293",
-              width: reconnecting ? "auto" : "34px",
-              whiteSpace: "nowrap",
+              letterSpacing: ".04em",
+              color: paused ? "#efe9da" : reconnecting ? "var(--amb)" : "#6f6a5d",
+              minWidth: "44px",
               textAlign: "right",
             }}
           >
-            {reconnecting ? `⟳ ${item.progress}%` : `${item.progress}%`}
+            {paused ? `Ⅱ ${item.progress}%` : reconnecting ? `⟳ ${item.progress}%` : `${item.progress}%`}
           </span>
         </div>
       )}
@@ -781,6 +811,8 @@ function BatchBar({ batch, isMobile }: { batch: BatchSummary; isMobile: boolean 
 function Tray({
   items,
   onCancel,
+  onPause,
+  onResume,
   onDownload,
   onDownloadAll,
   isMobile,
@@ -788,6 +820,8 @@ function Tray({
 }: {
   items: TransferItem[];
   onCancel: (id: string) => void;
+  onPause: (id: string) => void;
+  onResume: (id: string) => void;
   onDownload: (id: string) => void;
   onDownloadAll: () => void;
   isMobile: boolean;
@@ -870,6 +904,8 @@ function Tray({
             key={item.id}
             item={item}
             onCancel={onCancel}
+            onPause={onPause}
+            onResume={onResume}
             onDownload={onDownload}
             isMobile={isMobile}
             peerLabel={labelForPeer?.(item.peerId)}
@@ -1205,6 +1241,8 @@ export function SessionView({
   onSendFiles,
   onSendText,
   onCancel,
+  onPause,
+  onResume,
   onDownloadOne,
   onDownloadAll,
   isMobile,
@@ -1221,6 +1259,8 @@ export function SessionView({
   onSendFiles: (files: File[]) => void;
   onSendText: (text: string) => void;
   onCancel: (id: string) => void;
+  onPause: (id: string) => void;
+  onResume: (id: string) => void;
   onDownloadOne: (id: string) => void;
   onDownloadAll: () => void;
   isMobile: boolean;
@@ -1340,6 +1380,8 @@ export function SessionView({
       <Tray
         items={items}
         onCancel={onCancel}
+        onPause={onPause}
+        onResume={onResume}
         onDownload={onDownloadOne}
         onDownloadAll={onDownloadAll}
         isMobile={isMobile}

--- a/web/src/transfer/TransferFlow.tsx
+++ b/web/src/transfer/TransferFlow.tsx
@@ -210,6 +210,8 @@ export default function TransferFlow({ joinCode }: { joinCode?: string }) {
                 onSendFiles={wrap.sendFiles}
                 onSendText={wrap.sendText}
                 onCancel={wrap.cancel}
+                onPause={wrap.pause}
+                onResume={wrap.resume}
                 onDownloadOne={wrap.downloadOne}
                 onDownloadAll={wrap.downloadAll}
                 isMobile={isMobile}

--- a/web/src/transfer/TransferFlow.tsx
+++ b/web/src/transfer/TransferFlow.tsx
@@ -6,6 +6,7 @@ import WarpLogo from "../WarpLogo";
 import { useWarpTransfer, type Connection, type WarpError } from "../lib/warp/useWarpTransfer";
 import { formatBytes } from "../lib/warp/transfer";
 import { useIsMobile } from "../lib/useIsMobile";
+import { useTransferTitle } from "../lib/useTransferTitle";
 import { copyToClipboard } from "../lib/copyToClipboard";
 import { AcceptModal, SessionView } from "./SessionView";
 
@@ -39,6 +40,9 @@ export default function TransferFlow({ joinCode }: { joinCode?: string }) {
   const wrap = useWarpTransfer(joinCode);
   const { mode, code, shareUrl, status, items, incoming, error, connections } = wrap;
   const isMobile = useIsMobile();
+
+  // #15: live progress in the tab title while any transfer is in flight.
+  useTransferTitle(items);
 
   // Local file queue (sender only). Each gets a stable id for list keys/removal.
   const [queue, setQueue] = useState<QueuedFile[]>([]);


### PR DESCRIPTION
## Summary
Two tiny-friction QOL wins from the roadmap.

**#15 — live progress in the tab title.** While any file transfer is in flight, `document.title` becomes `↑ 42% · Warp` (arrow is direction-aware: ↑ send, ↓ receive, ⇅ both). Throttled to 1 write/sec, restored to the route title when the last item finishes. Shared `useTransferTitle` hook covers both the code-room flow and the nearby LAN flow.

**#14 — warn before closing mid-transfer.** Native `beforeunload` prompt (sender and receiver, plus nearby) only while something is transferring/reconnecting/paused; listener removed the instant nothing is in flight so an idle tab keeps bfcache and the landing page never nags.

Verified: typecheck, lint, build, both check harnesses pass. Depends on #247 (uses the `paused` status).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pause and resume controls for nearby and ongoing file transfers.
  * Paused transfers retain progress and can resume without restarting.
  * Browser tab titles now show live transfer direction and progress.
  * Added a warning before leaving the page while transfers are active or paused.
  * Transfer panels now display paused status, progress, and controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds transfer progress to the browser tab title, unload warnings while transfers are active, and pause/resume controls across code-room and nearby flows.

- Adds a shared throttled transfer-title hook and integrates it into both transfer surfaces.
- Registers `beforeunload` protection only while transfers are transferring, reconnecting, or paused.
- Extends peer signaling, transfer state, hooks, tests, and UI controls for pausing and resuming files.
- The nearby receive path currently restarts paused files instead of continuing from their durable offset.
</details>

<h3>Confidence Score: 4/5</h3>

The nearby pause/resume defect should be fixed before merging because resumed receives currently discard their saved progress and retransmit from the beginning.

The code-room flow carries durable offsets through re-offers, but the nearby flow uses a new offer ID, the default ID-keyed receive host, and no resume-offset map, so its advertised resume behavior cannot continue the retained partial transfer; the title hook also has a non-blocking stale-route-title edge case.

**Files Needing Attention:** web/src/nearby/useNearbyTransfer.ts and web/src/lib/useTransferTitle.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/src/nearby/useNearbyTransfer.ts | Adds nearby pause/resume and unload protection, but receive resume does not preserve or report the paused sink's durable offset. |
| web/src/lib/useTransferTitle.ts | Adds throttled progress titles, with a stale captured-title restoration edge case across TransferFlow route changes. |
| web/src/lib/warp/peer.ts | Extends peer signaling and transfer pumping with pause semantics while intentionally retaining receive sinks. |
| web/src/lib/warp/useWarpTransfer.ts | Adds durable code-room pause/resume orchestration and conditional unload protection. |
| web/src/transfer/SessionView.tsx | Adds paused-state rendering and pause, resume, and cancel controls to transfer rows. |

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aweb%2Fsrc%2Fnearby%2FuseNearbyTransfer.ts%3A301%0A**Nearby%20resume%20loses%20partial%20state**%0A%0AWhen%20a%20user%20resumes%20a%20partially%20received%20nearby%20file%2C%20this%20requests%20a%20new%20offer%20but%20%60acceptIncoming%60%20supplies%20neither%20the%20retained%20sink%20nor%20its%20durable%20offset.%20The%20new%20offer%20therefore%20starts%20from%20byte%20zero%20under%20a%20fresh%20ID-keyed%20sink%2C%20resetting%20progress%2C%20retransmitting%20the%20full%20file%2C%20and%20retaining%20the%20orphaned%20partial%20sink%20for%20the%20peer's%20lifetime.%0A%0A%23%23%23%20Issue%202%0Aweb%2Fsrc%2Flib%2FuseTransferTitle.ts%3A55-58%0A**Cleanup%20restores%20stale%20route%20title**%0A%0AWhen%20navigation%20switches%20between%20%60%2Fsend%60%20and%20%60%2Fr%2F%3Ccode%3E%60%20during%20an%20active%20transfer%2C%20the%20same%20%60TransferFlow%60%20remains%20mounted%20but%20%60prev%60%20still%20contains%20the%20original%20route%20title.%20Completing%20the%20transfer%20restores%20that%20stale%20title%2C%20which%20remains%20visible%20until%20another%20route%20change%20reruns%20the%20SEO%20effect.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ishannaik%2Fwarp&pr=249&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ishannaik%2Fwarp%22%20on%20the%20existing%20branch%20%22feat%2Fqol-15-14%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fqol-15-14%22.%0A%0A%23%23%23%20Issue%201%0Aweb%2Fsrc%2Fnearby%2FuseNearbyTransfer.ts%3A301%0A**Nearby%20resume%20loses%20partial%20state**%0A%0AWhen%20a%20user%20resumes%20a%20partially%20received%20nearby%20file%2C%20this%20requests%20a%20new%20offer%20but%20%60acceptIncoming%60%20supplies%20neither%20the%20retained%20sink%20nor%20its%20durable%20offset.%20The%20new%20offer%20therefore%20starts%20from%20byte%20zero%20under%20a%20fresh%20ID-keyed%20sink%2C%20resetting%20progress%2C%20retransmitting%20the%20full%20file%2C%20and%20retaining%20the%20orphaned%20partial%20sink%20for%20the%20peer's%20lifetime.%0A%0A%23%23%23%20Issue%202%0Aweb%2Fsrc%2Flib%2FuseTransferTitle.ts%3A55-58%0A**Cleanup%20restores%20stale%20route%20title**%0A%0AWhen%20navigation%20switches%20between%20%60%2Fsend%60%20and%20%60%2Fr%2F%3Ccode%3E%60%20during%20an%20active%20transfer%2C%20the%20same%20%60TransferFlow%60%20remains%20mounted%20but%20%60prev%60%20still%20contains%20the%20original%20route%20title.%20Completing%20the%20transfer%20restores%20that%20stale%20title%2C%20which%20remains%20visible%20until%20another%20route%20change%20reruns%20the%20SEO%20effect.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ishannaik%2Fwarp&pr=249&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Aweb%2Fsrc%2Fnearby%2FuseNearbyTransfer.ts%3A301%0A**Nearby%20resume%20loses%20partial%20state**%0A%0AWhen%20a%20user%20resumes%20a%20partially%20received%20nearby%20file%2C%20this%20requests%20a%20new%20offer%20but%20%60acceptIncoming%60%20supplies%20neither%20the%20retained%20sink%20nor%20its%20durable%20offset.%20The%20new%20offer%20therefore%20starts%20from%20byte%20zero%20under%20a%20fresh%20ID-keyed%20sink%2C%20resetting%20progress%2C%20retransmitting%20the%20full%20file%2C%20and%20retaining%20the%20orphaned%20partial%20sink%20for%20the%20peer's%20lifetime.%0A%0A%23%23%23%20Issue%202%0Aweb%2Fsrc%2Flib%2FuseTransferTitle.ts%3A55-58%0A**Cleanup%20restores%20stale%20route%20title**%0A%0AWhen%20navigation%20switches%20between%20%60%2Fsend%60%20and%20%60%2Fr%2F%3Ccode%3E%60%20during%20an%20active%20transfer%2C%20the%20same%20%60TransferFlow%60%20remains%20mounted%20but%20%60prev%60%20still%20contains%20the%20original%20route%20title.%20Completing%20the%20transfer%20restores%20that%20stale%20title%2C%20which%20remains%20visible%20until%20another%20route%20change%20reruns%20the%20SEO%20effect.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=249&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/nearby/useNearbyTransfer.ts:301
**Nearby resume loses partial state**

When a user resumes a partially received nearby file, this requests a new offer but `acceptIncoming` supplies neither the retained sink nor its durable offset. The new offer therefore starts from byte zero under a fresh ID-keyed sink, resetting progress, retransmitting the full file, and retaining the orphaned partial sink for the peer's lifetime.

### Issue 2
web/src/lib/useTransferTitle.ts:55-58
**Cleanup restores stale route title**

When navigation switches between `/send` and `/r/<code>` during an active transfer, the same `TransferFlow` remains mounted but `prev` still contains the original route title. Completing the transfer restores that stale title, which remains visible until another route change reruns the SEO effect.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(warp): tab-title progress + warn-be..."](https://github.com/ishannaik/warp/commit/345385bff2f68cb714e26e8dad8bf2547ab19012) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51538627)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->