### PR TITLE
test(web): add useIsMobile check harness

### DIFF
--- a/web/src/lib/useIsMobile.check.mjs
+++ b/web/src/lib/useIsMobile.check.mjs
@@ -1,0 +1,135 @@
+/**
+ * Dependency-free check for useIsMobile.ts. React's two hooks are stubbed so
+ * the hook can be driven from Node without adding a browser test framework.
+ *
+ * Run from web/: node src/lib/useIsMobile.check.mjs
+ */
+
+import assert from "node:assert";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+let useIsMobile;
+try {
+  const esbuild = await import("esbuild");
+  const out = await esbuild.build({
+    entryPoints: [path.join(here, "useIsMobile.ts")],
+    bundle: true,
+    format: "esm",
+    write: false,
+    platform: "neutral",
+    plugins: [
+      {
+        name: "react-hook-stub",
+        setup(build) {
+          build.onResolve({ filter: /^react$/ }, () => ({
+            path: "react-stub",
+            namespace: "hook-stub",
+          }));
+          build.onLoad({ filter: /.*/, namespace: "hook-stub" }, () => ({
+            loader: "js",
+            contents: `
+              export function useState(initial) {
+                const value = typeof initial === "function" ? initial() : initial;
+                globalThis.__hookState = value;
+                return [value, (next) => {
+                  globalThis.__hookState = typeof next === "function"
+                    ? next(globalThis.__hookState)
+                    : next;
+                }];
+              }
+              export function useEffect(effect) {
+                globalThis.__hookCleanup = effect();
+              }
+            `,
+          }));
+        },
+      },
+    ],
+  });
+  const code = out.outputFiles[0].text;
+  const dataUrl = `data:text/javascript;base64,${Buffer.from(code).toString("base64")}`;
+  ({ useIsMobile } = await import(dataUrl));
+} catch (error) {
+  console.error("SKIP: esbuild not available to transpile useIsMobile.ts —", error.message);
+  process.exit(0);
+}
+
+function setWindow(value) {
+  if (value === undefined) {
+    delete globalThis.window;
+    return;
+  }
+  Object.defineProperty(globalThis, "window", {
+    value,
+    configurable: true,
+    writable: true,
+  });
+}
+
+function mediaQuery(matches) {
+  const listeners = new Set();
+  return {
+    matches,
+    addEventListener(type, listener) {
+      assert.equal(type, "change");
+      listeners.add(listener);
+    },
+    removeEventListener(type, listener) {
+      assert.equal(type, "change");
+      listeners.delete(listener);
+    },
+    emit(next) {
+      this.matches = next;
+      for (const listener of listeners) listener({ matches: next });
+    },
+    listenerCount() {
+      return listeners.size;
+    },
+  };
+}
+
+// SSR / environments without matchMedia: safe desktop default.
+setWindow(undefined);
+globalThis.__hookCleanup = undefined;
+assert.equal(useIsMobile(), false);
+assert.equal(globalThis.__hookState, false);
+
+// Boundary is inclusive and read synchronously on the first render.
+{
+  const mql = mediaQuery(true);
+  setWindow({
+    matchMedia(query) {
+      assert.equal(query, "(max-width: 767px)");
+      return mql;
+    },
+  });
+
+  globalThis.__hookCleanup = undefined;
+  assert.equal(useIsMobile(767), true);
+  assert.equal(globalThis.__hookState, true);
+  assert.equal(mql.listenerCount(), 1, "subscribes to one change listener");
+
+  mql.emit(false);
+  assert.equal(globalThis.__hookState, false, "change event updates mobile state");
+
+  globalThis.__hookCleanup?.();
+  assert.equal(mql.listenerCount(), 0, "cleanup removes the change listener");
+}
+
+// A custom breakpoint is reflected in the media query.
+{
+  const mql = mediaQuery(false);
+  setWindow({
+    matchMedia(query) {
+      assert.equal(query, "(max-width: 420px)");
+      return mql;
+    },
+  });
+  assert.equal(useIsMobile(420), false);
+  globalThis.__hookCleanup?.();
+}
+
+console.log("OK: useIsMobile (initial state, breakpoint, change subscription, cleanup, SSR guard)");

--- a/web/src/lib/useIsMobile.check.mjs
+++ b/web/src/lib/useIsMobile.check.mjs
@@ -10,52 +10,45 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
-
-let useIsMobile;
-try {
-  const esbuild = await import("esbuild");
-  const out = await esbuild.build({
-    entryPoints: [path.join(here, "useIsMobile.ts")],
-    bundle: true,
-    format: "esm",
-    write: false,
-    platform: "neutral",
-    plugins: [
-      {
-        name: "react-hook-stub",
-        setup(build) {
-          build.onResolve({ filter: /^react$/ }, () => ({
-            path: "react-stub",
-            namespace: "hook-stub",
-          }));
-          build.onLoad({ filter: /.*/, namespace: "hook-stub" }, () => ({
-            loader: "js",
-            contents: `
-              export function useState(initial) {
-                const value = typeof initial === "function" ? initial() : initial;
-                globalThis.__hookState = value;
-                return [value, (next) => {
-                  globalThis.__hookState = typeof next === "function"
-                    ? next(globalThis.__hookState)
-                    : next;
-                }];
-              }
-              export function useEffect(effect) {
-                globalThis.__hookCleanup = effect();
-              }
-            `,
-          }));
-        },
+const esbuild = await import("esbuild");
+const out = await esbuild.build({
+  entryPoints: [path.join(here, "useIsMobile.ts")],
+  bundle: true,
+  format: "esm",
+  write: false,
+  platform: "neutral",
+  plugins: [
+    {
+      name: "react-hook-stub",
+      setup(build) {
+        build.onResolve({ filter: /^react$/ }, () => ({
+          path: "react-stub",
+          namespace: "hook-stub",
+        }));
+        build.onLoad({ filter: /.*/, namespace: "hook-stub" }, () => ({
+          loader: "js",
+          contents: `
+            export function useState(initial) {
+              const value = typeof initial === "function" ? initial() : initial;
+              globalThis.__hookState = value;
+              return [value, (next) => {
+                globalThis.__hookState = typeof next === "function"
+                  ? next(globalThis.__hookState)
+                  : next;
+              }];
+            }
+            export function useEffect(effect) {
+              globalThis.__hookCleanup = effect();
+            }
+          `,
+        }));
       },
-    ],
-  });
-  const code = out.outputFiles[0].text;
-  const dataUrl = `data:text/javascript;base64,${Buffer.from(code).toString("base64")}`;
-  ({ useIsMobile } = await import(dataUrl));
-} catch (error) {
-  console.error("SKIP: esbuild not available to transpile useIsMobile.ts —", error.message);
-  process.exit(0);
-}
+    },
+  ],
+});
+const code = out.outputFiles[0].text;
+const dataUrl = `data:text/javascript;base64,${Buffer.from(code).toString("base64")}`;
+const { useIsMobile } = await import(dataUrl);
 
 function setWindow(value) {
   if (value === undefined) {
@@ -91,11 +84,19 @@ function mediaQuery(matches) {
   };
 }
 
-// SSR / environments without matchMedia: safe desktop default.
+// SSR: no window means a safe desktop default.
 setWindow(undefined);
 globalThis.__hookCleanup = undefined;
 assert.equal(useIsMobile(), false);
 assert.equal(globalThis.__hookState, false);
+assert.equal(globalThis.__hookCleanup, undefined);
+
+// Browser-like environment where window exists but matchMedia is unavailable.
+setWindow({});
+globalThis.__hookCleanup = undefined;
+assert.equal(useIsMobile(), false);
+assert.equal(globalThis.__hookState, false);
+assert.equal(globalThis.__hookCleanup, undefined);
 
 // Boundary is inclusive and read synchronously on the first render.
 {
@@ -132,4 +133,4 @@ assert.equal(globalThis.__hookState, false);
   globalThis.__hookCleanup?.();
 }
 
-console.log("OK: useIsMobile (initial state, breakpoint, change subscription, cleanup, SSR guard)");
+console.log("OK: useIsMobile (initial state, breakpoint, change subscription, cleanup, SSR + missing-matchMedia guards)");

--- a/web/src/lib/warp/useIsMobile.check.mjs
+++ b/web/src/lib/warp/useIsMobile.check.mjs
@@ -1,0 +1,2 @@
+/** Register the colocated hook harness with the standard CI check runner. */
+await import("../useIsMobile.check.mjs");


### PR DESCRIPTION
Closes #107

Adds a dependency-free check harness for `useIsMobile.ts`, following Warp's existing `.check.mjs` convention.

Covers the synchronous initial media-query read, breakpoint behavior, change-event updates, the missing-`matchMedia` guard, and listener cleanup.

No production code changes. Tests/build were not run locally in this environment; CI can validate the branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated coverage for mobile viewport detection across server-rendered and browser environments.
  * Verified default and custom breakpoints, including boundary values.
  * Added checks for initial responsive state, viewport change updates, event listener handling, and cleanup.
  * The validation runs without requiring additional runtime dependencies and skips gracefully when the test tooling is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds a dependency-free check harness for `useIsMobile` and registers it with the standard CI check runner.
- Covers SSR and browser environments, including an existing `window` without `matchMedia`.
- Checks initial state, breakpoint boundaries, change events, and listener cleanup.
- Adds a discoverable wrapper under `src/lib/warp` so CI executes the colocated harness.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the current code addresses all three previously reported issues.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/src/lib/useIsMobile.check.mjs | Adds the hook harness and resolves the prior error-masking and missing-`matchMedia` coverage findings. |
| web/src/lib/warp/useIsMobile.check.mjs | Registers the harness in the directory discovered by the standard CI runner. |

<sub>Reviews (2): Last reviewed commit: ["test: register useIsMobile harness in CI"](https://github.com/ishannaik/warp/commit/9e283762cc10930154c28d07408f16b24af631b8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51541494)</sub>

<!-- /greptile_comment -->