### PR TITLE
test(web): add useDocumentSeo check harness

### DIFF
--- a/web/src/lib/useDocumentSeo.check.mjs
+++ b/web/src/lib/useDocumentSeo.check.mjs
@@ -1,0 +1,141 @@
+/**
+ * Dependency-free DOM check for useDocumentSeo.ts. The React effect is stubbed
+ * to run immediately so metadata behavior can be exercised from Node.
+ *
+ * Run from web/: node src/lib/useDocumentSeo.check.mjs
+ */
+
+import assert from "node:assert";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+let useDocumentSeo;
+try {
+  const esbuild = await import("esbuild");
+  const out = await esbuild.build({
+    entryPoints: [path.join(here, "useDocumentSeo.ts")],
+    bundle: true,
+    format: "esm",
+    write: false,
+    platform: "neutral",
+    plugins: [
+      {
+        name: "react-effect-stub",
+        setup(build) {
+          build.onResolve({ filter: /^react$/ }, () => ({
+            path: "react-stub",
+            namespace: "hook-stub",
+          }));
+          build.onLoad({ filter: /.*/, namespace: "hook-stub" }, () => ({
+            loader: "js",
+            contents: "export function useEffect(effect) { effect(); }",
+          }));
+        },
+      },
+    ],
+  });
+  const code = out.outputFiles[0].text;
+  const dataUrl = `data:text/javascript;base64,${Buffer.from(code).toString("base64")}`;
+  ({ useDocumentSeo } = await import(dataUrl));
+} catch (error) {
+  console.error("SKIP: esbuild not available to transpile useDocumentSeo.ts —", error.message);
+  process.exit(0);
+}
+
+function makeElement(tagName) {
+  const attrs = new Map();
+  return {
+    tagName,
+    setAttribute(name, value) {
+      attrs.set(name, value);
+    },
+    getAttribute(name) {
+      return attrs.get(name) ?? null;
+    },
+  };
+}
+
+function makeDocument() {
+  const elements = [];
+  const doc = {
+    title: "",
+    head: {
+      appendChild(element) {
+        elements.push(element);
+        return element;
+      },
+    },
+    createElement(tagName) {
+      return makeElement(tagName);
+    },
+    querySelector(selector) {
+      const meta = selector.match(/^meta\[(name|property)="([^"]+)"\]$/);
+      if (meta) {
+        const [, attr, key] = meta;
+        return (
+          elements.find(
+            (element) => element.tagName === "meta" && element.getAttribute(attr) === key,
+          ) ?? null
+        );
+      }
+      if (selector === 'link[rel="canonical"]') {
+        return (
+          elements.find(
+            (element) => element.tagName === "link" && element.getAttribute("rel") === "canonical",
+          ) ?? null
+        );
+      }
+      return null;
+    },
+    __elements: elements,
+  };
+  return doc;
+}
+
+const documentStub = makeDocument();
+Object.defineProperty(globalThis, "document", {
+  value: documentStub,
+  configurable: true,
+  writable: true,
+});
+
+useDocumentSeo("First page", "First description", "/first");
+assert.equal(documentStub.title, "First page");
+assert.equal(documentStub.querySelector('meta[name="description"]').getAttribute("content"), "First description");
+assert.equal(documentStub.querySelector('meta[property="og:title"]').getAttribute("content"), "First page");
+assert.equal(documentStub.querySelector('meta[name="twitter:title"]').getAttribute("content"), "First page");
+assert.equal(
+  documentStub.querySelector('link[rel="canonical"]').getAttribute("href"),
+  "https://warp.ishannaik.com/first",
+);
+assert.equal(
+  documentStub.querySelector('meta[property="og:url"]').getAttribute("content"),
+  "https://warp.ishannaik.com/first",
+);
+
+const countAfterFirst = documentStub.__elements.length;
+useDocumentSeo("Second page", "Second description", "/second");
+assert.equal(documentStub.title, "Second page");
+assert.equal(documentStub.querySelector('meta[name="description"]').getAttribute("content"), "Second description");
+assert.equal(
+  documentStub.querySelector('link[rel="canonical"]').getAttribute("href"),
+  "https://warp.ishannaik.com/second",
+);
+assert.equal(
+  documentStub.__elements.length,
+  countAfterFirst,
+  "updating route metadata reuses existing tags instead of duplicating them",
+);
+
+const descriptionTags = documentStub.__elements.filter(
+  (element) => element.tagName === "meta" && element.getAttribute("name") === "description",
+);
+assert.equal(descriptionTags.length, 1, "there is exactly one description meta tag");
+
+// The hook is SSR-safe and simply no-ops when document is unavailable.
+delete globalThis.document;
+assert.doesNotThrow(() => useDocumentSeo("SSR page", "ignored", "/ssr"));
+
+console.log("OK: useDocumentSeo (title, create/update metadata, canonical URL, no duplicates, SSR guard)");

--- a/web/src/lib/useDocumentSeo.check.mjs
+++ b/web/src/lib/useDocumentSeo.check.mjs
@@ -10,39 +10,32 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
-
-let useDocumentSeo;
-try {
-  const esbuild = await import("esbuild");
-  const out = await esbuild.build({
-    entryPoints: [path.join(here, "useDocumentSeo.ts")],
-    bundle: true,
-    format: "esm",
-    write: false,
-    platform: "neutral",
-    plugins: [
-      {
-        name: "react-effect-stub",
-        setup(build) {
-          build.onResolve({ filter: /^react$/ }, () => ({
-            path: "react-stub",
-            namespace: "hook-stub",
-          }));
-          build.onLoad({ filter: /.*/, namespace: "hook-stub" }, () => ({
-            loader: "js",
-            contents: "export function useEffect(effect) { effect(); }",
-          }));
-        },
+const esbuild = await import("esbuild");
+const out = await esbuild.build({
+  entryPoints: [path.join(here, "useDocumentSeo.ts")],
+  bundle: true,
+  format: "esm",
+  write: false,
+  platform: "neutral",
+  plugins: [
+    {
+      name: "react-effect-stub",
+      setup(build) {
+        build.onResolve({ filter: /^react$/ }, () => ({
+          path: "react-stub",
+          namespace: "hook-stub",
+        }));
+        build.onLoad({ filter: /.*/, namespace: "hook-stub" }, () => ({
+          loader: "js",
+          contents: "export function useEffect(effect) { effect(); }",
+        }));
       },
-    ],
-  });
-  const code = out.outputFiles[0].text;
-  const dataUrl = `data:text/javascript;base64,${Buffer.from(code).toString("base64")}`;
-  ({ useDocumentSeo } = await import(dataUrl));
-} catch (error) {
-  console.error("SKIP: esbuild not available to transpile useDocumentSeo.ts —", error.message);
-  process.exit(0);
-}
+    },
+  ],
+});
+const code = out.outputFiles[0].text;
+const dataUrl = `data:text/javascript;base64,${Buffer.from(code).toString("base64")}`;
+const { useDocumentSeo } = await import(dataUrl);
 
 function makeElement(tagName) {
   const attrs = new Map();

--- a/web/src/lib/warp/useDocumentSeo.check.mjs
+++ b/web/src/lib/warp/useDocumentSeo.check.mjs
@@ -1,0 +1,2 @@
+/** Register the colocated hook harness with the standard CI check runner. */
+await import("../useDocumentSeo.check.mjs");


### PR DESCRIPTION
Closes #108

Adds a dependency-free DOM check harness for `useDocumentSeo.ts`.

Covers document-title updates plus creation/update behavior for description, canonical, Open Graph, and Twitter metadata, including repeated updates without duplicate-tag leakage.

No production code changes. Tests/build were not run locally in this environment; CI can validate the branch.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds a dependency-free DOM harness for `useDocumentSeo` and registers it with the standard engine-check runner.
- Exercises title, description, canonical, Open Graph, and Twitter metadata creation and updates.
- Verifies repeated updates do not create duplicate tags and confirms SSR-safe behavior.
- Propagates harness setup, compilation, import, and assertion failures to automated checks.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/src/lib/useDocumentSeo.check.mjs | Adds the SEO hook harness with fail-closed setup and assertions covering metadata creation, updates, deduplication, and SSR behavior. |
| web/src/lib/warp/useDocumentSeo.check.mjs | Registers the SEO harness with the standard check runner through an awaited import that preserves failures. |

<sub>Reviews (2): Last reviewed commit: ["test: register useDocumentSeo harness in..."](https://github.com/ishannaik/warp/commit/19e7eeb93eb7729a91931fa5ab64e1f23db57d1f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51541505)</sub>

<!-- /greptile_comment -->