### PR TITLE
test(web): add useReducedMotion check harness

### DIFF
--- a/web/src/lib/useReducedMotion.check.mjs
+++ b/web/src/lib/useReducedMotion.check.mjs
@@ -1,0 +1,122 @@
+/**
+ * Dependency-free check for useReducedMotion.ts. React hooks are stubbed so the
+ * media-query behavior can be exercised from Node without adding a test runner.
+ *
+ * Run from web/: node src/lib/useReducedMotion.check.mjs
+ */
+
+import assert from "node:assert";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+let useReducedMotion;
+try {
+  const esbuild = await import("esbuild");
+  const out = await esbuild.build({
+    entryPoints: [path.join(here, "useReducedMotion.ts")],
+    bundle: true,
+    format: "esm",
+    write: false,
+    platform: "neutral",
+    plugins: [
+      {
+        name: "react-hook-stub",
+        setup(build) {
+          build.onResolve({ filter: /^react$/ }, () => ({
+            path: "react-stub",
+            namespace: "hook-stub",
+          }));
+          build.onLoad({ filter: /.*/, namespace: "hook-stub" }, () => ({
+            loader: "js",
+            contents: `
+              export function useState(initial) {
+                const value = typeof initial === "function" ? initial() : initial;
+                globalThis.__hookState = value;
+                return [value, (next) => {
+                  globalThis.__hookState = typeof next === "function"
+                    ? next(globalThis.__hookState)
+                    : next;
+                }];
+              }
+              export function useEffect(effect) {
+                globalThis.__hookCleanup = effect();
+              }
+            `,
+          }));
+        },
+      },
+    ],
+  });
+  const code = out.outputFiles[0].text;
+  const dataUrl = `data:text/javascript;base64,${Buffer.from(code).toString("base64")}`;
+  ({ useReducedMotion } = await import(dataUrl));
+} catch (error) {
+  console.error("SKIP: esbuild not available to transpile useReducedMotion.ts —", error.message);
+  process.exit(0);
+}
+
+function setWindow(value) {
+  if (value === undefined) {
+    delete globalThis.window;
+    return;
+  }
+  Object.defineProperty(globalThis, "window", {
+    value,
+    configurable: true,
+    writable: true,
+  });
+}
+
+function mediaQuery(matches) {
+  const listeners = new Set();
+  return {
+    matches,
+    addEventListener(type, listener) {
+      assert.equal(type, "change");
+      listeners.add(listener);
+    },
+    removeEventListener(type, listener) {
+      assert.equal(type, "change");
+      listeners.delete(listener);
+    },
+    emit(next) {
+      this.matches = next;
+      for (const listener of listeners) listener({ matches: next });
+    },
+    listenerCount() {
+      return listeners.size;
+    },
+  };
+}
+
+// SSR / missing matchMedia falls back to normal motion without throwing.
+setWindow(undefined);
+globalThis.__hookCleanup = undefined;
+assert.equal(useReducedMotion(), false);
+assert.equal(globalThis.__hookState, false);
+
+// Initial preference is read synchronously and changes are subscribed to.
+{
+  const mql = mediaQuery(true);
+  setWindow({
+    matchMedia(query) {
+      assert.equal(query, "(prefers-reduced-motion: reduce)");
+      return mql;
+    },
+  });
+
+  globalThis.__hookCleanup = undefined;
+  assert.equal(useReducedMotion(), true);
+  assert.equal(globalThis.__hookState, true);
+  assert.equal(mql.listenerCount(), 1, "subscribes to the preference change event");
+
+  mql.emit(false);
+  assert.equal(globalThis.__hookState, false, "change event updates reduced-motion state");
+
+  globalThis.__hookCleanup?.();
+  assert.equal(mql.listenerCount(), 0, "cleanup removes the preference listener");
+}
+
+console.log("OK: useReducedMotion (initial preference, change subscription, cleanup, SSR guard)");

--- a/web/src/lib/useReducedMotion.check.mjs
+++ b/web/src/lib/useReducedMotion.check.mjs
@@ -10,52 +10,45 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
-
-let useReducedMotion;
-try {
-  const esbuild = await import("esbuild");
-  const out = await esbuild.build({
-    entryPoints: [path.join(here, "useReducedMotion.ts")],
-    bundle: true,
-    format: "esm",
-    write: false,
-    platform: "neutral",
-    plugins: [
-      {
-        name: "react-hook-stub",
-        setup(build) {
-          build.onResolve({ filter: /^react$/ }, () => ({
-            path: "react-stub",
-            namespace: "hook-stub",
-          }));
-          build.onLoad({ filter: /.*/, namespace: "hook-stub" }, () => ({
-            loader: "js",
-            contents: `
-              export function useState(initial) {
-                const value = typeof initial === "function" ? initial() : initial;
-                globalThis.__hookState = value;
-                return [value, (next) => {
-                  globalThis.__hookState = typeof next === "function"
-                    ? next(globalThis.__hookState)
-                    : next;
-                }];
-              }
-              export function useEffect(effect) {
-                globalThis.__hookCleanup = effect();
-              }
-            `,
-          }));
-        },
+const esbuild = await import("esbuild");
+const out = await esbuild.build({
+  entryPoints: [path.join(here, "useReducedMotion.ts")],
+  bundle: true,
+  format: "esm",
+  write: false,
+  platform: "neutral",
+  plugins: [
+    {
+      name: "react-hook-stub",
+      setup(build) {
+        build.onResolve({ filter: /^react$/ }, () => ({
+          path: "react-stub",
+          namespace: "hook-stub",
+        }));
+        build.onLoad({ filter: /.*/, namespace: "hook-stub" }, () => ({
+          loader: "js",
+          contents: `
+            export function useState(initial) {
+              const value = typeof initial === "function" ? initial() : initial;
+              globalThis.__hookState = value;
+              return [value, (next) => {
+                globalThis.__hookState = typeof next === "function"
+                  ? next(globalThis.__hookState)
+                  : next;
+              }];
+            }
+            export function useEffect(effect) {
+              globalThis.__hookCleanup = effect();
+            }
+          `,
+        }));
       },
-    ],
-  });
-  const code = out.outputFiles[0].text;
-  const dataUrl = `data:text/javascript;base64,${Buffer.from(code).toString("base64")}`;
-  ({ useReducedMotion } = await import(dataUrl));
-} catch (error) {
-  console.error("SKIP: esbuild not available to transpile useReducedMotion.ts —", error.message);
-  process.exit(0);
-}
+    },
+  ],
+});
+const code = out.outputFiles[0].text;
+const dataUrl = `data:text/javascript;base64,${Buffer.from(code).toString("base64")}`;
+const { useReducedMotion } = await import(dataUrl);
 
 function setWindow(value) {
   if (value === undefined) {
@@ -91,11 +84,19 @@ function mediaQuery(matches) {
   };
 }
 
-// SSR / missing matchMedia falls back to normal motion without throwing.
+// SSR: no window falls back to normal motion without throwing.
 setWindow(undefined);
 globalThis.__hookCleanup = undefined;
 assert.equal(useReducedMotion(), false);
 assert.equal(globalThis.__hookState, false);
+assert.equal(globalThis.__hookCleanup, undefined);
+
+// Browser-like environment where window exists but matchMedia is unavailable.
+setWindow({});
+globalThis.__hookCleanup = undefined;
+assert.equal(useReducedMotion(), false);
+assert.equal(globalThis.__hookState, false);
+assert.equal(globalThis.__hookCleanup, undefined);
 
 // Initial preference is read synchronously and changes are subscribed to.
 {
@@ -119,4 +120,4 @@ assert.equal(globalThis.__hookState, false);
   assert.equal(mql.listenerCount(), 0, "cleanup removes the preference listener");
 }
 
-console.log("OK: useReducedMotion (initial preference, change subscription, cleanup, SSR guard)");
+console.log("OK: useReducedMotion (initial preference, change subscription, cleanup, SSR + missing-matchMedia guards)");

--- a/web/src/lib/warp/useReducedMotion.check.mjs
+++ b/web/src/lib/warp/useReducedMotion.check.mjs
@@ -1,0 +1,2 @@
+/** Register the colocated hook harness with the standard CI check runner. */
+await import("../useReducedMotion.check.mjs");


### PR DESCRIPTION
Closes #109

Adds a dependency-free check harness for `useReducedMotion.ts`, matching the lightweight hook-test pattern.

Covers the synchronous initial preference read, preference changes, the missing-`matchMedia` guard, and listener cleanup.

No production code changes. Tests/build were not run locally in this environment; CI can validate the branch.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds a dependency-free harness for `useReducedMotion` and registers it with the standard engine-check runner.
- Exercises SSR and missing-`matchMedia` fallbacks.
- Verifies synchronous preference initialization, change subscription, state updates, and listener cleanup.
- Adds a discoverable forwarding check under `src/lib/warp`.
- Allows esbuild, bundling, and generated-module import failures to propagate to CI.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/src/lib/useReducedMotion.check.mjs | Adds the hook harness and now allows setup, build, and import failures to terminate the check unsuccessfully. |
| web/src/lib/warp/useReducedMotion.check.mjs | Registers the hook harness in the directory scanned by the standard engine-check runner. |

<sub>Reviews (2): Last reviewed commit: ["test: register useReducedMotion harness ..."](https://github.com/ishannaik/warp/commit/e0a94fdf386eb3123d8e9f420bcf6d87dd889910) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51541512)</sub>

<!-- /greptile_comment -->