### PR TITLE
ci: report high-severity dependency audit findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,22 @@ jobs:
               - 'pnpm-lock.yaml'
               - '.github/workflows/ci.yml'
 
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: '.nvmrc'
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      # Report high/critical advisories on every run without blocking contributor
+      # CI yet; once the signal proves stable this can become a hard gate.
+      - name: Audit dependencies (high+)
+        continue-on-error: true
+        run: pnpm audit --audit-level=high
+
   web:
     needs: changes
     if: ${{ needs.changes.outputs.web == 'true' }}


### PR DESCRIPTION
Closes #116

Adds a lightweight `pnpm audit --audit-level=high` check to CI after dependency installation.

The audit is intentionally report-only for now: high-severity findings are surfaced in CI, but registry/advisory availability does not become a new contributor-blocking failure mode on day one. The workflow comments document that choice.

Workflow/build checks were not run locally in this environment; CI can validate the change.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds a report-only dependency audit job to CI.
- Installs the pnpm workspace using the repository’s pinned Node and package-manager configuration.
- Runs `pnpm audit --audit-level=high` on every workflow run.
- Keeps audit and registry failures non-blocking with `continue-on-error`.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The new job uses the repository’s established Node, pnpm, caching, and frozen-lockfile setup, while its non-blocking behavior and unconditional execution match the documented report-only intent.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Adds an independently running, non-blocking high-severity dependency audit job consistent with the repository’s existing CI setup. |

<sub>Reviews (1): Last reviewed commit: ["ci: report high-severity dependency advi..."](https://github.com/ishannaik/warp/commit/c5c755e83f4619daa744ee08d45f0bfc031cdb26) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51541525)</sub>

<!-- /greptile_comment -->