### PR TITLE
build: add multi-stage frontend Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+.github
+**/node_modules
+**/dist
+**/.DS_Store
+.env
+.env.*
+!.env.example

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM node:22-alpine AS build
+
+WORKDIR /app
+RUN corepack enable
+
+COPY . .
+RUN pnpm install --frozen-lockfile
+
+# Optional: bake a custom signaling relay into the Vite bundle. Leaving the
+# argument unset preserves Warp's built-in Cloudflare signaling default.
+ARG VITE_SIGNALING_URL
+RUN if [ -n "$VITE_SIGNALING_URL" ]; then \
+      VITE_SIGNALING_URL="$VITE_SIGNALING_URL" pnpm --filter @warp/web build; \
+    else \
+      pnpm --filter @warp/web build; \
+    fi
+
+FROM nginx:1.27-alpine AS runtime
+
+COPY docker/nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/web/dist /usr/share/nginx/html
+
+EXPOSE 80

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,0 +1,11 @@
+server {
+  listen 80;
+  server_name _;
+
+  root /usr/share/nginx/html;
+  index index.html;
+
+  location / {
+    try_files $uri $uri/ /index.html;
+  }
+}

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -5,6 +5,26 @@ server {
   root /usr/share/nginx/html;
   index index.html;
 
+  # Match the browser hardening applied by web/public/_headers on Cloudflare.
+  add_header X-Content-Type-Options "nosniff" always;
+  add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+  add_header X-Frame-Options "SAMEORIGIN" always;
+  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+  add_header Permissions-Policy "geolocation=(), microphone=(), camera=(self)" always;
+
+  # Vite emits content-hashed assets, so they can be cached immutably.
+  # Nginx does not inherit server-level add_header directives when a location
+  # defines its own add_header, so repeat the security headers here as well.
+  location /assets/ {
+    try_files $uri =404;
+    add_header Cache-Control "public, max-age=31536000, immutable" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    add_header Permissions-Policy "geolocation=(), microphone=(), camera=(self)" always;
+  }
+
   location / {
     try_files $uri $uri/ /index.html;
   }


### PR DESCRIPTION
Closes #147

Adds a root multi-stage Docker build for the static Warp frontend.

- builds `@warp/web` with pnpm
- exposes `VITE_SIGNALING_URL` as a build argument
- serves the production bundle from a lean Nginx stage
- adds SPA fallback routing for deep links
- trims the Docker build context with `.dockerignore`

The existing Cloudflare deployment path is untouched. Docker/build checks were not run locally in this environment; CI/review can validate the image.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds a multi-stage Docker build for the Warp frontend and serves its production bundle through Nginx.
- Builds `@warp/web` with pnpm and supports a build-time signaling URL.
- Copies the generated frontend into a lean Nginx runtime image.
- Configures SPA fallback routing, browser security headers, and immutable caching for hashed assets.
- Reduces the Docker build context through `.dockerignore`.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; both previously reported Nginx configuration issues are fixed at the current head.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Dockerfile | Adds a Node-based frontend build stage and a lean Nginx runtime stage with optional build-time signaling configuration. |
| docker/nginx.conf | Adds SPA routing and now fully mirrors the existing Cloudflare security-header and immutable-asset caching policies. |
| .dockerignore | Excludes repository metadata, generated dependencies, build output, local environment files, and OS metadata from the Docker context. |

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Builder as Node build stage
    participant Vite as @warp/web build
    participant Image as Nginx runtime image
    participant Browser
    Builder->>Vite: "pnpm --filter @warp/web build"
    Vite-->>Builder: web/dist
    Builder->>Image: Copy production bundle
    Browser->>Image: Request route or asset
    alt "/assets/*"
        Image-->>Browser: Hashed asset with immutable caching
    else Application route
        Image-->>Browser: index.html via SPA fallback
    end
```
</details>

<sub>Reviews (2): Last reviewed commit: ["build: mirror frontend security and cach..."](https://github.com/ishannaik/warp/commit/48bfaa90fe18e3f2d8f94c1e6de706f69fc953f7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51541533)</sub>

<!-- /greptile_comment -->