### PR TITLE
Pause/resume: cover the cancel-vs-pause distinction directly

### DIFF
--- a/web/src/lib/warp/receiveGuards.check.mjs
+++ b/web/src/lib/warp/receiveGuards.check.mjs
@@ -17,8 +17,8 @@ let esbuild;
 try {
   esbuild = await import("esbuild");
 } catch (e) {
-  console.error("SKIP: esbuild not available to transpile TS for this check —", e.message);
-  process.exit(0);
+  console.error("FAIL: esbuild is required for receiveGuards.check.mjs —", e.message);
+  process.exit(1);
 }
 
 const url = await import("node:url");

--- a/web/src/lib/warp/receiveGuards.check.mjs
+++ b/web/src/lib/warp/receiveGuards.check.mjs
@@ -1,0 +1,64 @@
+/**
+ * Runnable check for guardTargetFor in receiveGuards.ts (no test runner;
+ * matches roomCode.check.mjs style — transpiles the TS on the fly via esbuild).
+ *
+ * This is the mutation test from #257: guardTargetFor is the one line the
+ * whole pause/resume feature turns on (pause parks the key, cancel poisons
+ * the sink), and a mirrored harness that reproduces the hook's logic instead
+ * of calling the real export can't catch a regression in the line it mirrors.
+ *
+ * Run:  node src/lib/warp/receiveGuards.check.mjs   (from web/)
+ */
+
+import assert from "node:assert";
+
+// --- transpile receiveGuards.ts on the fly (esbuild if present) ------------
+let esbuild;
+try {
+  esbuild = await import("esbuild");
+} catch (e) {
+  console.error("SKIP: esbuild not available to transpile TS for this check —", e.message);
+  process.exit(0);
+}
+
+const url = await import("node:url");
+const path = await import("node:path");
+const here = path.dirname(url.fileURLToPath(import.meta.url));
+const out = await esbuild.build({
+  entryPoints: [path.join(here, "receiveGuards.ts")],
+  bundle: true,
+  format: "esm",
+  write: false,
+  platform: "neutral",
+});
+const code = out.outputFiles[0].text;
+const dataUrl = "data:text/javascript;base64," + Buffer.from(code).toString("base64");
+const mod = await import(dataUrl);
+
+const { guardTargetFor } = mod;
+
+// --- the one line the feature turns on: paused + receive -> "paused" -------
+assert.equal(
+  guardTargetFor("paused", "receive"),
+  "paused",
+  "a paused receive parks the key and must NOT poison the sink",
+);
+assert.notEqual(
+  guardTargetFor("paused", "receive"),
+  "cancelled",
+  "pause must never route to the cancelled set — resume depends on a healthy sink",
+);
+
+// --- direction: only receive carries a guard; send never does -------------
+for (const status of ["offered", "transferring", "reconnecting", "paused", "done", "declined", "cancelled", "error"]) {
+  assert.equal(guardTargetFor(status, "send"), "none", `send side never guards (status: ${status})`);
+}
+
+// --- status: every non-paused status on the receive side is "none" here ---
+// (cancel is handled by cancel()'s own path, not this listener — see the
+// comment in receiveGuards.ts.)
+for (const status of ["offered", "transferring", "reconnecting", "done", "declined", "cancelled", "error"]) {
+  assert.equal(guardTargetFor(status, "receive"), "none", `receive side only guards on "paused" (status: ${status})`);
+}
+
+console.log("OK: receiveGuards.ts guardTargetFor pause-vs-cancel decision, all statuses x both directions");

--- a/web/src/lib/warp/receiveGuards.ts
+++ b/web/src/lib/warp/receiveGuards.ts
@@ -1,0 +1,18 @@
+import type { Direction, TransferStatus } from "./transfer";
+
+/** Which guard set a status change belongs in. Pause parks the key; cancel
+ *  poisons it. Getting these backwards breaks resume. */
+export type GuardTarget = "paused" | "cancelled" | "none";
+
+/**
+ * Extracted so the pause-vs-cancel decision — the one line the whole
+ * pause/resume feature turns on — can be exercised by a `.check.mjs` harness
+ * directly, rather than only through a hand-mirrored copy of useWarpTransfer's
+ * logic that can't catch a regression in the line it mirrors.
+ */
+export function guardTargetFor(status: TransferStatus, direction: Direction): GuardTarget {
+  if (direction !== "receive") return "none";
+  if (status === "paused") return "paused";
+  if (status === "cancelled") return "none"; // cancel routes elsewhere, see cancel()
+  return "none";
+}

--- a/web/src/lib/warp/useWarpTransfer.ts
+++ b/web/src/lib/warp/useWarpTransfer.ts
@@ -45,6 +45,7 @@ import { supportedCodecs } from "./compress";
 import { streamZipDownload } from "./zipDownload";
 import { formatBytes, type OfferItem, type TransferItem } from "./transfer";
 import { SpeedTracker } from "./transferStats";
+import { guardTargetFor } from "./receiveGuards";
 
 /**
  * One in-flight (or paused) incoming file's durable state, owned by the HOOK
@@ -509,7 +510,7 @@ export function useWarpTransfer(joinCode?: string): UseWarpTransfer {
         // A pause (local or remote) must park the durable entry inactive and
         // remember the key so an unrelated reconnect does not auto-resume.
         // Unlike cancel, the sink stays healthy.
-        if (item.status === "paused" && item.direction === "receive") {
+        if (guardTargetFor(item.status, item.direction) === "paused") {
           const key = rxIdKeyRef.current.get(item.id);
           if (key) {
             pausedKeysRef.current.add(key);


### PR DESCRIPTION
## Summary
Mutation-tested the pause/resume work from #247 after it merged. Changing the paused branch in `useWarpTransfer.ts` to poison the sink the way cancel does (swap `pausedKeysRef` for `cancelledKeysRef`) still passed `useWarpTransfer.check.mjs` — that's the one bug the whole feature turns on, and the harness mirrors the hook's logic with its own local `pausedKeys` Set instead of running the real code, so it can't catch a regression in the line it's mirroring.

- Extracted the decision into `guardTargetFor(status, direction)` in a new `receiveGuards.ts` — a pure function with no React import, so a `.check.mjs` can transpile and call the real export directly.
- `useWarpTransfer.ts`'s paused branch now calls it instead of the inline `status`/`direction` check; behavior is unchanged.
- `receiveGuards.check.mjs` asserts the real function, including the exact swap from this issue (`paused` -> `"cancelled"` instead of `"paused"`) as a would-be regression, plus every status × both directions.

Verified locally that `receiveGuards.check.mjs` fails when `guardTargetFor` is mutated to reproduce the swap, and passes on the correct code.

Closes #257

## Test plan
- [x] `npm run check:engine` — all 18 harnesses pass (17 existing + the new one)
- [x] `npm run typecheck` — clean
- [x] `npx eslint src/lib/warp/receiveGuards.ts src/lib/warp/useWarpTransfer.ts` — clean (2 pre-existing, unrelated warnings elsewhere in `useWarpTransfer.ts`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected transfer guard behavior so paused receive transfers are tracked as paused.
  * Ensured cancelled and non-paused receive transfers, along with send transfers, are not incorrectly guarded.

* **Tests**
  * Added automated checks covering paused, cancelled, non-paused, and send transfer scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR extracts the paused-receive guard decision into a pure helper so the production decision can be tested directly without changing transfer behavior.
- Adds `guardTargetFor` to distinguish paused incoming transfers from cancellation and unrelated states.
- Updates `useWarpTransfer` to use the extracted helper.
- Adds a harness covering every transfer-status and direction combination.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the extracted helper preserves existing behavior and the new harness directly covers the intended pause-versus-cancel distinction.

The production condition remains true only for paused incoming transfers, all other defined status and direction combinations remain unguarded, and the extraction introduces no runtime import cycle.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/src/lib/warp/receiveGuards.ts | Introduces a pure, exhaustive guard helper that preserves the former paused-receive condition. |
| web/src/lib/warp/useWarpTransfer.ts | Replaces the inline paused-receive conjunction with the behaviorally equivalent helper call. |
| web/src/lib/warp/receiveGuards.check.mjs | Exercises the production helper across every defined status and direction, including the pause-versus-cancel regression case. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Transfer status event] --> B{Direction is receive?}
    B -- No --> C[Guard target: none]
    B -- Yes --> D{Status is paused?}
    D -- Yes --> E[Guard target: paused]
    D -- No --> C
    E --> F[Park receive key without poisoning sink]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["test: cover the pause-vs-cancel guard de..."](https://github.com/ishannaik/warp/commit/2ca658808e5b3762fcc85c7108764af9d2aeff2f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51586450)</sub>

<!-- /greptile_comment -->