### PR TITLE
Convert HEIC/HEIF images to JPEG on receive

### DIFF
--- a/web/src/lib/warp/imageConvert.check.mjs
+++ b/web/src/lib/warp/imageConvert.check.mjs
@@ -12,8 +12,8 @@ let esbuild;
 try {
   esbuild = await import("esbuild");
 } catch (e) {
-  console.error("SKIP: esbuild not available to transpile TS for this check —", e.message);
-  process.exit(0);
+  console.error("FAIL: esbuild is required for imageConvert.check.mjs —", e.message);
+  process.exit(1);
 }
 
 const url = await import("node:url");
@@ -30,7 +30,7 @@ const code = out.outputFiles[0].text;
 const dataUrl = "data:text/javascript;base64," + Buffer.from(code).toString("base64");
 const mod = await import(dataUrl);
 
-const { isHeicMime, jpegFilename, convertToJpeg } = mod;
+const { isHeicMime, jpegFilename, convertToJpeg, exceedsConvertSizeCap } = mod;
 
 // --- isHeicMime ---
 assert.equal(isHeicMime("image/heic"), true, "image/heic is targeted");
@@ -51,4 +51,15 @@ assert.equal(jpegFilename("noext"), "noext.jpg", "no extension: appends one rath
 const result = await convertToJpeg(new Blob(["not a real image"]));
 assert.equal(result, undefined, "with no document/createImageBitmap, conversion is skipped, not thrown");
 
-console.log("OK: imageConvert.ts isHeicMime + jpegFilename + convertToJpeg's no-DOM feature-detect path");
+// --- exceedsConvertSizeCap: tested directly, not through convertToJpeg, since
+// in a no-DOM environment (this check) every oversized-input call would also
+// return undefined via the DOM feature-detect below it — masking a regression
+// in the cap itself. Regression coverage for the P1 finding on #260: an
+// eager, unbounded decode of a dimension-heavy photo could stall the tab or
+// exhaust memory before the user ever asked for a JPEG.
+const CAP = 50 * 1024 * 1024;
+assert.equal(exceedsConvertSizeCap(CAP), false, "exactly at the cap is allowed");
+assert.equal(exceedsConvertSizeCap(CAP + 1), true, "one byte over the cap is rejected");
+assert.equal(exceedsConvertSizeCap(0), false, "an empty source is allowed");
+
+console.log("OK: imageConvert.ts isHeicMime + jpegFilename + convertToJpeg's no-DOM feature-detect path + the size cap");

--- a/web/src/lib/warp/imageConvert.check.mjs
+++ b/web/src/lib/warp/imageConvert.check.mjs
@@ -1,0 +1,54 @@
+/**
+ * Runnable check for imageConvert.ts (no test runner; matches roomCode.check.mjs
+ * style — transpiles the TS on the fly via esbuild).
+ *
+ * Run:  node src/lib/warp/imageConvert.check.mjs   (from web/)
+ */
+
+import assert from "node:assert";
+
+// --- transpile imageConvert.ts on the fly (esbuild if present) -------------
+let esbuild;
+try {
+  esbuild = await import("esbuild");
+} catch (e) {
+  console.error("SKIP: esbuild not available to transpile TS for this check —", e.message);
+  process.exit(0);
+}
+
+const url = await import("node:url");
+const path = await import("node:path");
+const here = path.dirname(url.fileURLToPath(import.meta.url));
+const out = await esbuild.build({
+  entryPoints: [path.join(here, "imageConvert.ts")],
+  bundle: true,
+  format: "esm",
+  write: false,
+  platform: "neutral",
+});
+const code = out.outputFiles[0].text;
+const dataUrl = "data:text/javascript;base64," + Buffer.from(code).toString("base64");
+const mod = await import(dataUrl);
+
+const { isHeicMime, jpegFilename, convertToJpeg } = mod;
+
+// --- isHeicMime ---
+assert.equal(isHeicMime("image/heic"), true, "image/heic is targeted");
+assert.equal(isHeicMime("image/heif"), true, "image/heif is targeted");
+assert.equal(isHeicMime("image/jpeg"), false, "image/jpeg is not targeted");
+assert.equal(isHeicMime("image/png"), false, "image/png is not targeted");
+assert.equal(isHeicMime(""), false, "empty mime is not targeted");
+
+// --- jpegFilename ---
+assert.equal(jpegFilename("photo.heic"), "photo.jpg", "swaps the extension");
+assert.equal(jpegFilename("photo.HEIC"), "photo.jpg", "swaps a mixed-case extension too");
+assert.equal(jpegFilename("my.trip.heic"), "my.trip.jpg", "only the LAST extension is swapped");
+assert.equal(jpegFilename("noext"), "noext.jpg", "no extension: appends one rather than mangling the name");
+
+// --- convertToJpeg: feature-detects out cleanly with no DOM (Node has neither
+// `document` nor `createImageBitmap`) — this IS the "browser can't decode"
+// path from the caller's point of view, and must never throw.
+const result = await convertToJpeg(new Blob(["not a real image"]));
+assert.equal(result, undefined, "with no document/createImageBitmap, conversion is skipped, not thrown");
+
+console.log("OK: imageConvert.ts isHeicMime + jpegFilename + convertToJpeg's no-DOM feature-detect path");

--- a/web/src/lib/warp/imageConvert.ts
+++ b/web/src/lib/warp/imageConvert.ts
@@ -13,16 +13,33 @@ export function isHeicMime(mime: string): boolean {
   return mime === "image/heic" || mime === "image/heif";
 }
 
+// Same ceiling and reasoning as THUMB_SOURCE_MAX in peer.ts's makeThumb: this
+// runs eagerly (on receipt, not on click), so an unbounded decode + full-size
+// canvas + encode of a dimension-heavy photo would stall the tab or exhaust
+// memory before the user ever asked for a JPEG. Above this, the option is
+// skipped — the original stays downloadable either way.
+const CONVERT_SOURCE_MAX = 50 * 1024 * 1024;
+
+/** Extracted so the cap is testable on its own, independent of DOM/createImageBitmap
+ *  availability (a Node check has neither, which would otherwise mask this branch). */
+export function exceedsConvertSizeCap(byteLength: number): boolean {
+  return byteLength > CONVERT_SOURCE_MAX;
+}
+
 /**
  * Converts `source` to a JPEG Blob, or undefined if the browser can't decode
- * it. Safari decodes HEIC; most others do not — `createImageBitmap` rejecting
- * IS the feature detection here, so the caller can skip the option entirely
+ * it (or the file is too large to convert eagerly — see exceedsConvertSizeCap).
+ * Safari decodes HEIC; most others do not — `createImageBitmap` rejecting IS
+ * the feature detection here, so the caller can skip the option entirely
  * rather than shipping a ~1 MB wasm HEIC decoder for a minority file type.
  *
  * Full-size draw (not thumbnail scale, unlike makeThumb in peer.ts): this
- * produces the file the user saves, not a preview.
+ * produces the file the user saves, not a preview. Never rejects — every
+ * failure path (decode, canvas allocation, draw, encode) resolves to
+ * undefined, since the caller treats this as best-effort with no `.catch`.
  */
 export async function convertToJpeg(source: Blob, quality = 0.92): Promise<Blob | undefined> {
+  if (exceedsConvertSizeCap(source.size)) return undefined;
   if (typeof document === "undefined" || typeof createImageBitmap !== "function") return undefined;
   let bitmap: ImageBitmap;
   try {
@@ -40,6 +57,8 @@ export async function convertToJpeg(source: Blob, quality = 0.92): Promise<Blob 
     return await new Promise<Blob | undefined>((resolve) => {
       canvas.toBlob((blob) => resolve(blob ?? undefined), "image/jpeg", quality);
     });
+  } catch {
+    return undefined;
   } finally {
     bitmap.close();
   }

--- a/web/src/lib/warp/imageConvert.ts
+++ b/web/src/lib/warp/imageConvert.ts
@@ -1,0 +1,53 @@
+/**
+ * Best-effort HEIC/HEIF -> JPEG conversion for the receive-side "Save as JPEG"
+ * option (#258). An iPhone photo saved as `.heic` won't open on most Windows
+ * and Linux machines; PairDrop converts these on the fly and this mirrors it.
+ *
+ * Offer conversion, never force it: the receiver already accepted the
+ * original file, so the caller must keep it downloadable regardless of what
+ * this returns.
+ */
+
+/** Mime types this option targets. */
+export function isHeicMime(mime: string): boolean {
+  return mime === "image/heic" || mime === "image/heif";
+}
+
+/**
+ * Converts `source` to a JPEG Blob, or undefined if the browser can't decode
+ * it. Safari decodes HEIC; most others do not — `createImageBitmap` rejecting
+ * IS the feature detection here, so the caller can skip the option entirely
+ * rather than shipping a ~1 MB wasm HEIC decoder for a minority file type.
+ *
+ * Full-size draw (not thumbnail scale, unlike makeThumb in peer.ts): this
+ * produces the file the user saves, not a preview.
+ */
+export async function convertToJpeg(source: Blob, quality = 0.92): Promise<Blob | undefined> {
+  if (typeof document === "undefined" || typeof createImageBitmap !== "function") return undefined;
+  let bitmap: ImageBitmap;
+  try {
+    bitmap = await createImageBitmap(source);
+  } catch {
+    return undefined;
+  }
+  try {
+    const canvas = document.createElement("canvas");
+    canvas.width = bitmap.width;
+    canvas.height = bitmap.height;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return undefined;
+    ctx.drawImage(bitmap, 0, 0);
+    return await new Promise<Blob | undefined>((resolve) => {
+      canvas.toBlob((blob) => resolve(blob ?? undefined), "image/jpeg", quality);
+    });
+  } finally {
+    bitmap.close();
+  }
+}
+
+/** Swaps (or appends) a `.jpg` extension onto a HEIC/HEIF filename. */
+export function jpegFilename(name: string): string {
+  const dot = name.lastIndexOf(".");
+  const stem = dot > 0 ? name.slice(0, dot) : name;
+  return `${stem}.jpg`;
+}

--- a/web/src/transfer/SessionView.tsx
+++ b/web/src/transfer/SessionView.tsx
@@ -15,7 +15,7 @@
  * the global keyframes media query.
  */
 
-import { memo, useMemo, useRef, useState } from "react";
+import { memo, useEffect, useMemo, useRef, useState } from "react";
 import type { CSSProperties } from "react";
 import {
   TEXT_SNIPPET_MAX_BYTES,
@@ -30,6 +30,7 @@ import { copyToClipboard } from "../lib/copyToClipboard";
 import type { Connection, TransferStats } from "../lib/warp/useWarpTransfer";
 import { formatDuration, formatSpeed } from "../lib/warp/transferStats";
 import { detectFsAccessSupport, isLargeBatch } from "../lib/warp/receiveStrategy";
+import { convertToJpeg, isHeicMime, jpegFilename } from "../lib/warp/imageConvert";
 
 const MONO = "'JetBrains Mono',monospace";
 const DISPLAY = "'Bricolage Grotesque',sans-serif";
@@ -52,6 +53,20 @@ function typeGlyph(mime: string, kind: TransferItem["kind"]): string {
 /** Aggregate size label for a manifest. */
 function totalBytes(items: { size: number }[]): number {
   return items.reduce((s, i) => s + i.size, 0);
+}
+
+/** Trigger a browser download of a blob via a transient object-URL anchor
+ *  (same small helper duplicated per-file elsewhere — useWarpTransfer.ts,
+ *  useNearbyTransfer.ts, zipDownload.ts — rather than shared). */
+function saveBlob(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
 }
 
 /* ----------------------------------------------------------------- thumbnail */
@@ -157,6 +172,27 @@ const ItemRow = memo(function ItemRow({
     item.status === "done" &&
     !item.savedToDisk &&
     !!item.blob;
+
+  // "Save as JPEG" (#258): converted eagerly (not on click) so the option can
+  // be offered-or-skipped correctly — createImageBitmap rejecting on this
+  // browser/file IS the "can't decode HEIC" signal, and there's no way to know
+  // that without attempting it. undefined = not attempted or not decodable
+  // (button stays hidden either way); a Blob means the button appears.
+  const [jpeg, setJpeg] = useState<Blob | undefined>(undefined);
+  const wantsJpeg = canDownload && isHeicMime(item.mime);
+  useEffect(() => {
+    if (!wantsJpeg || !item.blob) return;
+    let cancelled = false;
+    convertToJpeg(item.blob).then((blob) => {
+      if (!cancelled) setJpeg(blob);
+    });
+    return () => {
+      cancelled = true;
+    };
+    // item.blob is stable for the lifetime of a "done" item; re-running this
+    // per progress tick would re-decode the same file repeatedly.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [wantsJpeg, item.id]);
 
   const copyText = async () => {
     if (!item.text) return;
@@ -281,6 +317,28 @@ const ItemRow = memo(function ItemRow({
               }}
             >
               Download
+            </button>
+          )}
+          {canDownload && jpeg && (
+            <button
+              type="button"
+              className="warp-cta"
+              onClick={() => saveBlob(jpeg, jpegFilename(item.name))}
+              title="The original stays available via Download"
+              style={{
+                padding: "8px 14px",
+                background: "transparent",
+                color: "var(--acc)",
+                border: "1px solid var(--acc)",
+                fontFamily: MONO,
+                fontSize: "11px",
+                fontWeight: 600,
+                letterSpacing: ".06em",
+                textTransform: "uppercase",
+                cursor: "pointer",
+              }}
+            >
+              Save as JPEG
             </button>
           )}
           {savedToDisk && (


### PR DESCRIPTION
## Summary
An iPhone photo received as `.heic` won't open on most Windows and Linux machines. PairDrop converts these on the fly; Warp had neither built this nor filed it until now.

- `imageConvert.ts`: `convertToJpeg()` decodes via `createImageBitmap` and draws to a canvas at full size (not thumbnail scale, unlike `makeThumb` in `peer.ts`). A rejected decode IS the feature-detection — most browsers can't decode HEIC today, so the caller skips the option entirely rather than shipping a ~1 MB wasm decoder.
- `SessionView`'s `ItemRow` converts eagerly (not on click) once a received item is a done, in-memory HEIC/HEIF file — only that way can the option correctly not appear on a browser that can't decode it. On success, a "Save as JPEG" button appears beside the existing Download button; the original stays downloadable either way.
- `imageConvert.check.mjs` covers `isHeicMime`, `jpegFilename`, and `convertToJpeg`'s no-DOM feature-detect path (Node has neither `document` nor `createImageBitmap`, exercising the same "can't decode" branch a real unsupported browser would take).

Disk-streamed large batches are out of scope (no in-memory blob to convert there — same gate the existing Download button already uses). Bundling a wasm HEIC decoder is explicitly out of scope per the issue.

Closes #258

## Test plan
- [x] `npm run check:engine` — all 18 harnesses pass (17 existing + the new one)
- [x] `npm run typecheck` — clean
- [x] `npm run build` (vite build) — clean
- [x] `npx eslint src/transfer/SessionView.tsx src/lib/warp/imageConvert.ts` — clean
- [ ] Not manually exercised on Safari with a real `.heic` file (I don't have one on hand) — the no-DOM feature-detect path is covered; a maintainer with Safari + a real HEIC photo can confirm the happy path

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds receive-side HEIC/HEIF detection, eager browser-native conversion, and a “Save as JPEG” action while retaining the original download.

- Adds full-resolution HEIC/HEIF-to-JPEG conversion through ImageBitmap and canvas APIs.
- Starts conversion when an eligible in-memory transfer completes and exposes a separate JPEG download button.
- Adds a lightweight Node check for MIME detection, filename conversion, and unsupported-environment behavior.
</details>

<h3>Confidence Score: 3/5</h3>

This PR should not merge until automatic full-resolution conversion of peer-provided images is bounded or moved behind explicit user action.

Completed HEIC/HEIF transfers immediately trigger unrestricted bitmap decoding, canvas allocation, and JPEG encoding, allowing large-dimension or numerous images to exhaust receiver resources; canvas-stage failures can also escape as unhandled rejections.

**Files Needing Attention:** web/src/transfer/SessionView.tsx and web/src/lib/warp/imageConvert.ts

<details open><summary><h3>Security Review</h3></summary>

The eager conversion path automatically performs unbounded full-resolution decoding and canvas allocation on peer-provided images. A dimension-heavy image or qualifying batch can exhaust receiver CPU or memory; conversion should be explicitly initiated or constrained by size, pixel-count, and concurrency limits.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| web/src/lib/warp/imageConvert.ts | Introduces native full-resolution conversion, but leaves canvas failures uncaught and applies no resource bounds. |
| web/src/transfer/SessionView.tsx | Adds eager per-item conversion and JPEG download UI; automatic unconstrained work creates a receiver resource-exhaustion path. |
| web/src/lib/warp/imageConvert.check.mjs | Covers MIME and filename helpers plus the no-DOM path, without exercising browser conversion behavior. |

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant P as Sending peer
    participant R as Receive pipeline
    participant V as ItemRow
    participant C as convertToJpeg
    participant B as Browser canvas
    P->>R: Offer and transfer HEIC/HEIF item
    R->>V: Completed in-memory TransferItem
    V->>C: Eagerly convert item.blob
    C->>B: Decode full-resolution bitmap
    C->>B: Allocate same-size canvas and encode JPEG
    B-->>C: JPEG blob or failure
    C-->>V: JPEG blob or undefined
    V-->>V: Show Save as JPEG when successful
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aweb%2Fsrc%2Ftransfer%2FSessionView.tsx%3A183-186%0A**Unbounded%20eager%20image%20conversion**%0A%0AWhen%20an%20accepted%20peer%20sends%20a%20dimension-heavy%20HEIC%2FHEIF%20image%20or%20a%20qualifying%20batch%2C%20this%20effect%20automatically%20starts%20full-resolution%20decoding%2C%20canvas%20allocation%2C%20and%20JPEG%20encoding%20without%20size%2C%20pixel-count%2C%20or%20concurrency%20bounds%2C%20causing%20the%20receiver%20tab%20to%20stall%20or%20exhaust%20memory.%20**How%20this%20was%20verified%3A**%20Sender-provided%20MIME%20metadata%20reaches%20this%20effect%2C%20which%20passes%20the%20received%20blob%20to%20a%20converter%20that%20sizes%20its%20canvas%20directly%20from%20the%20full%20decoded%20dimensions.%0A%0A%23%23%23%20Issue%202%0Aweb%2Fsrc%2Flib%2Fwarp%2FimageConvert.ts%3A33-45%0A**Canvas%20failures%20escape%20conversion**%0A%0AAfter%20decoding%20succeeds%2C%20exceptions%20from%20canvas%20allocation%2C%20%60drawImage%60%2C%20or%20%60toBlob%60%20reject%20%60convertToJpeg%60%20instead%20of%20returning%20%60undefined%60%3B%20the%20sole%20caller%20has%20no%20rejection%20handler%2C%20so%20a%20best-effort%20conversion%20failure%20becomes%20an%20unhandled%20promise%20rejection.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ishannaik%2Fwarp&pr=260&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ishannaik%2Fwarp%22%20on%20the%20existing%20branch%20%22feat%2Fheic-to-jpeg-258%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fheic-to-jpeg-258%22.%0A%0A%23%23%23%20Issue%201%0Aweb%2Fsrc%2Ftransfer%2FSessionView.tsx%3A183-186%0A**Unbounded%20eager%20image%20conversion**%0A%0AWhen%20an%20accepted%20peer%20sends%20a%20dimension-heavy%20HEIC%2FHEIF%20image%20or%20a%20qualifying%20batch%2C%20this%20effect%20automatically%20starts%20full-resolution%20decoding%2C%20canvas%20allocation%2C%20and%20JPEG%20encoding%20without%20size%2C%20pixel-count%2C%20or%20concurrency%20bounds%2C%20causing%20the%20receiver%20tab%20to%20stall%20or%20exhaust%20memory.%20**How%20this%20was%20verified%3A**%20Sender-provided%20MIME%20metadata%20reaches%20this%20effect%2C%20which%20passes%20the%20received%20blob%20to%20a%20converter%20that%20sizes%20its%20canvas%20directly%20from%20the%20full%20decoded%20dimensions.%0A%0A%23%23%23%20Issue%202%0Aweb%2Fsrc%2Flib%2Fwarp%2FimageConvert.ts%3A33-45%0A**Canvas%20failures%20escape%20conversion**%0A%0AAfter%20decoding%20succeeds%2C%20exceptions%20from%20canvas%20allocation%2C%20%60drawImage%60%2C%20or%20%60toBlob%60%20reject%20%60convertToJpeg%60%20instead%20of%20returning%20%60undefined%60%3B%20the%20sole%20caller%20has%20no%20rejection%20handler%2C%20so%20a%20best-effort%20conversion%20failure%20becomes%20an%20unhandled%20promise%20rejection.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ishannaik%2Fwarp&pr=260&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Aweb%2Fsrc%2Ftransfer%2FSessionView.tsx%3A183-186%0A**Unbounded%20eager%20image%20conversion**%0A%0AWhen%20an%20accepted%20peer%20sends%20a%20dimension-heavy%20HEIC%2FHEIF%20image%20or%20a%20qualifying%20batch%2C%20this%20effect%20automatically%20starts%20full-resolution%20decoding%2C%20canvas%20allocation%2C%20and%20JPEG%20encoding%20without%20size%2C%20pixel-count%2C%20or%20concurrency%20bounds%2C%20causing%20the%20receiver%20tab%20to%20stall%20or%20exhaust%20memory.%20**How%20this%20was%20verified%3A**%20Sender-provided%20MIME%20metadata%20reaches%20this%20effect%2C%20which%20passes%20the%20received%20blob%20to%20a%20converter%20that%20sizes%20its%20canvas%20directly%20from%20the%20full%20decoded%20dimensions.%0A%0A%23%23%23%20Issue%202%0Aweb%2Fsrc%2Flib%2Fwarp%2FimageConvert.ts%3A33-45%0A**Canvas%20failures%20escape%20conversion**%0A%0AAfter%20decoding%20succeeds%2C%20exceptions%20from%20canvas%20allocation%2C%20%60drawImage%60%2C%20or%20%60toBlob%60%20reject%20%60convertToJpeg%60%20instead%20of%20returning%20%60undefined%60%3B%20the%20sole%20caller%20has%20no%20rejection%20handler%2C%20so%20a%20best-effort%20conversion%20failure%20becomes%20an%20unhandled%20promise%20rejection.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=260&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/transfer/SessionView.tsx:183-186
**Unbounded eager image conversion**

When an accepted peer sends a dimension-heavy HEIC/HEIF image or a qualifying batch, this effect automatically starts full-resolution decoding, canvas allocation, and JPEG encoding without size, pixel-count, or concurrency bounds, causing the receiver tab to stall or exhaust memory. **How this was verified:** Sender-provided MIME metadata reaches this effect, which passes the received blob to a converter that sizes its canvas directly from the full decoded dimensions.

### Issue 2
web/src/lib/warp/imageConvert.ts:33-45
**Canvas failures escape conversion**

After decoding succeeds, exceptions from canvas allocation, `drawImage`, or `toBlob` reject `convertToJpeg` instead of returning `undefined`; the sole caller has no rejection handler, so a best-effort conversion failure becomes an unhandled promise rejection.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: convert HEIC/HEIF to JPEG on recei..."](https://github.com/ishannaik/warp/commit/b1b56142a1089fff4792418f613196d34ddd0d61) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51586484)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->