### PR TITLE
Structured NAT-failure panel (#32) + friendly device names (#26)

### DIFF
--- a/web/src/lib/warp/deviceName.check.mjs
+++ b/web/src/lib/warp/deviceName.check.mjs
@@ -1,0 +1,39 @@
+// Harness for deviceName.ts (#26): determinism, format, distribution sanity,
+// and collision behavior across a realistic id population. Run: node deviceName.check.mjs
+import assert from "node:assert/strict";
+import { deviceName } from "./deviceName.ts";
+
+// 1. Deterministic: same id → same name across many calls.
+const id = "b9845b64-a11e-4c17-9f52-example0001";
+assert.equal(deviceName(id), deviceName(id));
+assert.equal(deviceName(id), deviceName(id));
+
+// 2. Format: word-word-twoDigits.
+const name = deviceName(id);
+assert.match(name, /^[a-z]+-[a-z]+-\d{2}$/, `format: ${name}`);
+
+// 3. Different ids get different names — tested on BOTH realistic shapes:
+//    sequential strings (worst case for a weak hash) and UUIDv4-ish ids.
+const shapes = [
+  (i) => `peer-${i}`,
+  (i) =>
+    `${i.toString(16).padStart(8, "0")}-a11e-4c17-9f52-${(i * 7919).toString(16).padStart(12, "0")}`,
+];
+for (const shape of shapes) {
+  const seen = new Map();
+  for (let i = 0; i < 5000; i++) {
+    const n = deviceName(shape(i));
+    assert.match(n, /^[a-z]+-[a-z]+-\d{2}$/);
+    seen.set(n, (seen.get(n) ?? 0) + 1);
+  }
+  const dupes = [...seen.values()].filter((c) => c > 1).length;
+  // Birthday math: 57,600 possible names (24·24·100) → ~215 expected
+  // collisions in 5,000 draws. Near that is healthy; a spike means a bad hash.
+  assert.ok(dupes <= 400, `collision rate too high (${dupes}/5000) for shape ${shape(0).slice(0, 8)}`);
+}
+
+// 4. Word parts come from fixed lists (no undefined/garbage slots).
+const [adj, noun] = name.split("-");
+assert.ok(adj.length >= 3 && noun.length >= 3);
+
+console.log("deviceName.check: OK — deterministic, well-formatted, low-collision");

--- a/web/src/lib/warp/deviceName.ts
+++ b/web/src/lib/warp/deviceName.ts
@@ -1,0 +1,50 @@
+// deviceName.ts — friendly, stable, offline device labels (#26).
+//
+// A peer id like "b9845b64-…" is unreadable in a room with two devices.
+// Instead we derive a deterministic label from the id's own bits: an adjective
+// + a noun + a 2-digit tail ("amber-otter-42"). Same id → same name, on both
+// peers, forever, with zero state and zero protocol change. The tail keeps
+// collisions readable even if two devices ever land on the same pair of words.
+
+const ADJECTIVES = [
+  "amber", "brisk", "calm", "clever", "dusk", "eager", "fond", "gentle",
+  "hazel", "ivory", "jolly", "keen", "lively", "mellow", "noble", "olive",
+  "plucky", "quiet", "rapid", "sturdy", "tidy", "urban", "vivid", "witty",
+];
+
+const NOUNS = [
+  "otter", "maple", "comet", "heron", "cedar", "falcon", "willow", "harbor",
+  "lynx", "quartz", "ember", "juniper", "badger", "lagoon", "sparrow", "basalt",
+  "cricket", "dahlia", "ferret", "garnet", "ibex", "kelpie", "martin", "nova",
+];
+
+/** Deterministic FNV-1a with a murmur-style finalizer — tiny, dependency-free.
+ *  The final mix is load-bearing: plain FNV's low bits mirror low input bits,
+ *  which skews any h % small-slot derivation (sequential ids collided ~3x the
+ *  birthday rate before this). */
+function fnv1a(input: string): number {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    h ^= input.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  h ^= h >>> 15;
+  h = Math.imul(h, 0x2545f491);
+  h ^= h >>> 13;
+  return h >>> 0;
+}
+
+/**
+ * Stable friendly name for a peer/device id. Pure function: the same id
+ * produces the same label everywhere (both peers see one shared name).
+ * Two independent FNV slices keep the word slots and the numeric tail from
+ * correlating (a shared modulus would skew collisions).
+ */
+export function deviceName(peerId: string): string {
+  const h = fnv1a(peerId);
+  const t = fnv1a(`tail:${peerId}`);
+  const adj = ADJECTIVES[h % ADJECTIVES.length];
+  const noun = NOUNS[Math.floor(h / ADJECTIVES.length) % NOUNS.length];
+  const tail = String(t % 100).padStart(2, "0");
+  return `${adj}-${noun}-${tail}`;
+}

--- a/web/src/lib/warp/useWarpTransfer.ts
+++ b/web/src/lib/warp/useWarpTransfer.ts
@@ -28,6 +28,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { SignalingClient, type SignalData } from "./signaling";
+import { deviceName } from "./deviceName";
 import {
   WarpPeer,
   type AcceptTarget,
@@ -205,9 +206,10 @@ const ERROR_MESSAGES: Record<WarpError["kind"], string> = {
 /** How long "reconnecting" may last before we surface an honest failure. */
 const RECONNECT_WATCHDOG_MS = 25_000;
 
-/** Short, stable label for a remote device id. */
+/** Short, stable, friendly label for a remote device id (#26) — deterministic
+ *  from the id itself, so both peers see the same name with zero state. */
 function labelFor(peerId: string): string {
-  return peerId.slice(0, 8);
+  return deviceName(peerId);
 }
 
 /**

--- a/web/src/theory/Theory.tsx
+++ b/web/src/theory/Theory.tsx
@@ -910,6 +910,18 @@ export default function Theory() {
   const isMobile = useIsMobile();
   const [activeLayer, setActiveLayer] = useState(0);
 
+  // Deep links like /how#nat (from the transfer error panel, issue #32): the
+  // client router renders after mount, so a plain browser hash-jump fires
+  // before the section exists. Re-run the scroll once rendering has settled.
+  useEffect(() => {
+    if (!window.location.hash) return;
+    const id = window.location.hash.slice(1);
+    const t = setTimeout(() => {
+      document.getElementById(id)?.scrollIntoView({ behavior: "smooth", block: "start" });
+    }, 60);
+    return () => clearTimeout(t);
+  }, []);
+
   /* PART B layer definitions — placeholder prose; Assemble fills from the doc. */
   const layers: LayerDef[] = [
     {
@@ -1360,8 +1372,10 @@ export default function Theory() {
         dark
       />
 
-      {/* A4 · NAT + STUN */}
+      {/* A4 · NAT + STUN — `nat` is the deep-link anchor from the transfer
+          error panel (issue #32). */}
       <Section
+        id="nat"
         eyebrow="04 / NAT traversal"
         heading="Finding a public address with STUN — and being honest when there isn't one."
         lede={

--- a/web/src/transfer/SessionView.tsx
+++ b/web/src/transfer/SessionView.tsx
@@ -28,6 +28,7 @@ import {
 } from "../lib/warp/transfer";
 import { copyToClipboard } from "../lib/copyToClipboard";
 import type { Connection, TransferStats } from "../lib/warp/useWarpTransfer";
+import { deviceName } from "../lib/warp/deviceName";
 import { formatDuration, formatSpeed } from "../lib/warp/transferStats";
 import { detectFsAccessSupport, isLargeBatch } from "../lib/warp/receiveStrategy";
 import { convertToJpeg, isHeicMime, jpegFilename } from "../lib/warp/imageConvert";
@@ -1349,7 +1350,7 @@ export function SessionView({
   // Map peerId -> label, so tray rows can name their to/from device.
   const labelForPeer = multiDevice
     ? (peerId?: string): string | undefined =>
-        peerId ? liveConnections.find((c) => c.peerId === peerId)?.label ?? peerId.slice(0, 8) : undefined
+        peerId ? liveConnections.find((c) => c.peerId === peerId)?.label ?? deviceName(peerId) : undefined
     : undefined;
 
   return (

--- a/web/src/transfer/TransferFlow.tsx
+++ b/web/src/transfer/TransferFlow.tsx
@@ -4,6 +4,7 @@ import QRCode from "qrcode";
 import { navigate } from "../router";
 import WarpLogo from "../WarpLogo";
 import { useWarpTransfer, type Connection, type WarpError } from "../lib/warp/useWarpTransfer";
+import { deviceName } from "../lib/warp/deviceName";
 import { formatBytes } from "../lib/warp/transfer";
 import { useIsMobile } from "../lib/useIsMobile";
 import { useTransferTitle } from "../lib/useTransferTitle";
@@ -113,7 +114,7 @@ export default function TransferFlow({ joinCode }: { joinCode?: string }) {
   // mesh room SessionView renders the per-device chips from `connections` itself.
   const peerLabel = useMemo(() => {
     const others = wrap.peers;
-    if (others.length) return others[0].slice(0, 8);
+    if (others.length) return deviceName(others[0]);
     return mode === "receive" ? "the sender" : "your peer";
   }, [wrap.peers, mode]);
 
@@ -121,7 +122,7 @@ export default function TransferFlow({ joinCode }: { joinCode?: string }) {
   const incomingPeerLabel = useMemo(() => {
     if (!incoming) return peerLabel;
     const match = connections.find((c) => c.peerId === incoming.peerId);
-    return match?.label ?? incoming.peerId.slice(0, 8);
+    return match?.label ?? deviceName(incoming.peerId);
   }, [incoming, connections, peerLabel]);
 
   return (
@@ -1054,6 +1055,17 @@ const ERROR_PANEL_COPY: Record<WarpError["kind"], { eyebrow: string; title: stri
   "too-large": { eyebrow: "Too large", title: "File too large." },
 };
 
+/** Issue #32 — ordered by real-world success rate. Same Wi-Fi always works
+ *  (LAN needs no punching); a hotspot is the same trick on demand; VPNs and
+ *  corporate firewalls are the most common culprits; some NATs are simply
+ *  flaky, so retry stays worth one shot. */
+const NAT_REMEDIES: string[] = [
+  "Put both devices on the same Wi-Fi — a local transfer needs no hole-punching at all.",
+  "No shared network? Hotspot one device to the other and reconnect.",
+  "Turn off any VPN, or leave the corporate/school network — those block peer connections.",
+  "Still stuck? Try once more — some routers only cooperate occasionally.",
+];
+
 function ErrorPanel({
   kind,
   message,
@@ -1109,11 +1121,102 @@ function ErrorPanel({
       >
         {copy.title}
       </h1>
-      <p style={{ fontSize: "15px", color: "#a8a293", margin: "0 auto 30px", maxWidth: "440px" }}>
-        {message}
-        {copy.natFooter &&
-          " Warp is STUN-only — there's no relay fallback, so some networks simply can't be bridged."}
-      </p>
+      {kind === "nat-failed" ? (
+        /* Issue #32: the honest-error IS the product for pairs that can't
+           punch through. Structured remedies instead of one flat paragraph. */
+        <div style={{ textAlign: "left", maxWidth: "500px", margin: "0 auto 30px" }}>
+          <p style={{ fontSize: "15px", color: "#a8a293", lineHeight: 1.55, margin: "0 0 16px", textAlign: "center" }}>
+            {message}
+          </p>
+          <div
+            style={{
+              border: `1px solid ${HAIRLINE}`,
+              background: "rgba(239,233,218,.02)",
+              padding: isMobile ? "14px 15px" : "16px 20px",
+            }}
+          >
+            <div
+              style={{
+                fontFamily: MONO,
+                fontSize: "11px",
+                letterSpacing: ".16em",
+                textTransform: "uppercase",
+                color: "#6f6a5d",
+                marginBottom: "8px",
+              }}
+            >
+              Why Warp stops here
+            </div>
+            <p style={{ fontSize: "13.5px", color: "#a8a293", lineHeight: 1.5, margin: 0 }}>
+              Your files never touch a server — so there is no relay to quietly route around a blocked network.
+              That refusal is the promise. This screen is what keeping it looks like.
+            </p>
+            <a
+              href="/how"
+              onClick={(e) => {
+                e.preventDefault();
+                navigate("/how#nat");
+              }}
+              style={{
+                display: "inline-block",
+                marginTop: "10px",
+                fontFamily: MONO,
+                fontSize: "12px",
+                letterSpacing: ".07em",
+                textTransform: "uppercase",
+                color: "var(--acc)",
+                textDecoration: "none",
+                borderBottom: "1px solid rgba(var(--acc-rgb),.5)",
+                paddingBottom: "1px",
+              }}
+            >
+              The full story →
+            </a>
+          </div>
+          <div style={{ marginTop: "20px" }}>
+            <div
+              style={{
+                fontFamily: MONO,
+                fontSize: "11px",
+                letterSpacing: ".16em",
+                textTransform: "uppercase",
+                color: "#6f6a5d",
+                marginBottom: "10px",
+              }}
+            >
+              What works, in order
+            </div>
+            {NAT_REMEDIES.map((remedy, i) => (
+              <div
+                key={remedy}
+                style={{
+                  display: "flex",
+                  gap: "12px",
+                  alignItems: "baseline",
+                  padding: isMobile ? "9px 0" : "7px 0",
+                  borderTop: i === 0 ? undefined : `1px solid rgba(239,233,218,.07)`,
+                }}
+              >
+                <span
+                  style={{
+                    fontFamily: MONO,
+                    fontSize: "11px",
+                    color: "var(--amb)",
+                    flexShrink: 0,
+                    width: "16px",
+                    textAlign: "right",
+                  }}
+                >
+                  {i + 1}
+                </span>
+                <span style={{ fontSize: "13.5px", color: "#efe9da", lineHeight: 1.45 }}>{remedy}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : (
+        <p style={{ fontSize: "15px", color: "#a8a293", margin: "0 auto 30px", maxWidth: "440px" }}>{message}</p>
+      )}
       <div
         style={{
           display: "flex",


### PR DESCRIPTION
## What

Two roadmap "Now"-tier items from a competitor-gap pass:

**#32 — NAT-failure troubleshooting panel.** When hole-punching fails, the error screen now branches on `error.kind`. For `nat-failed` it shows:

- What happened (symmetric-NAT framing)
- Why Warp stops here — the no-relay promise, stated plainly, linking `/how#nat` for the full story
- Four remedies ordered by real-world success rate: same Wi-Fi → hotspot → drop the VPN/corporate net → retry

Retry stays primary. `disconnected` / `channel-error` / `signaling` keep their own kind-appropriate copy instead of borrowing NAT framing. The theory page gained an `id="nat"` anchor plus a hash-scroll effect so the deep link lands on the right section after the client router renders.

**#26 — friendly device names.** Peer labels go from hex prefixes (`b9845b64`) to deterministic word names (`amber-otter-42`) derived from the peer id itself — zero state, zero protocol change, both peers see one shared name. Applied in the hook (`labelFor`), the joiner pills, accept-modal peer name, and tray to/from rows.

Implementation note: plain FNV-1a skewed ~3× the birthday rate on sequential ids because its low bits mirror low input bits; the finalizer mix fixes that, and `deviceName.check.mjs` pins collision rates on both sequential and UUID-shaped id populations.

## Verified locally

- typecheck · lint · **22 engine harnesses** (new deviceName.check included) — clean
- Playwright transfer E2E: chromium · webkit · firefox all byte-verified passes
- Lighthouse budgets pass (perf 0.99, JS well under 300 KB)

Closes #32, closes #26.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds structured NAT-failure guidance and deterministic friendly names throughout the transfer UI, plus a Theory-page NAT anchor and a collision-distribution harness.

- Replaces peer-ID prefixes with adjective-noun-number labels in connection chips, offer dialogs, and transfer rows.
- Adds NAT-specific troubleshooting steps and an internal link to the relevant Theory section.
- Adds deterministic-name format and collision checks.
</details>


<h3>Confidence Score: 4/5</h3>

The supported-runtime engine-check failure should be fixed before merging; duplicate friendly names are also worth disambiguating as a non-blocking UI improvement.

The new harness is automatically executed with plain Node but directly imports TypeScript, so documented Node 22 versions before 22.18 fail before any assertions run; the runtime product changes otherwise have only a low-probability peer-label ambiguity.

**Files Needing Attention:** web/src/lib/warp/deviceName.check.mjs, web/src/lib/warp/deviceName.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/src/lib/warp/deviceName.check.mjs | Adds useful deterministic and collision checks, but its direct TypeScript import breaks the engine harness on supported older Node 22 releases. |
| web/src/lib/warp/deviceName.ts | Adds stable friendly-name hashing, though the bounded namespace is not disambiguated when two active peers collide. |
| web/src/lib/warp/useWarpTransfer.ts | Centralizes friendly labels for connection state but does not resolve duplicate labels within a room. |
| web/src/transfer/TransferFlow.tsx | Adds NAT-specific recovery guidance and applies friendly names to peer and incoming-offer presentation. |
| web/src/transfer/SessionView.tsx | Applies friendly labels to transfer rows, with duplicate names remaining visually ambiguous. |
| web/src/theory/Theory.tsx | Adds a working NAT anchor and mount-time hash scrolling for the new error-panel deep link. |

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20ishannaik%2Fwarp%20PR%20%23324%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=ishannaik%2Fwarp&pr=324&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aweb%2Fsrc%2Flib%2Fwarp%2FdeviceName.check.mjs%3A4%0A**Direct%20TypeScript%20import%20breaks%20checks**%0A%0AWhen%20this%20harness%20runs%20on%20Node%2022.6%E2%80%9322.17%2C%20which%20satisfies%20the%20repository's%20Node%20%3E%3D22%20requirement%2C%20the%20direct%20%60.%2FdeviceName.ts%60%20import%20is%20rejected%20with%20%60ERR_UNKNOWN_FILE_EXTENSION%60%2C%20causing%20%60check%3Aengine%60%20to%20fail%20before%20these%20assertions%20run.%0A%0A%23%23%23%20Issue%202%0Aweb%2Fsrc%2Flib%2Fwarp%2FdeviceName.ts%3A43-49%0A**Friendly%20names%20remain%20collision-ambiguous**%0A%0ATwo%20peers%20whose%20IDs%20map%20to%20the%20same%20one%20of%2057%2C600%20labels%20receive%20identical%20names%20with%20no%20room-level%20disambiguation%2C%20leaving%20device%20chips%2C%20incoming-offer%20attribution%2C%20and%20transfer-row%20labels%20unable%20to%20distinguish%20those%20devices.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ishannaik%2Fwarp&pr=324&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ishannaik%2Fwarp%22%20on%20the%20existing%20branch%20%22nat-panel-device-names%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22nat-panel-device-names%22.%0A%0A%23%23%23%20Issue%201%0Aweb%2Fsrc%2Flib%2Fwarp%2FdeviceName.check.mjs%3A4%0A**Direct%20TypeScript%20import%20breaks%20checks**%0A%0AWhen%20this%20harness%20runs%20on%20Node%2022.6%E2%80%9322.17%2C%20which%20satisfies%20the%20repository's%20Node%20%3E%3D22%20requirement%2C%20the%20direct%20%60.%2FdeviceName.ts%60%20import%20is%20rejected%20with%20%60ERR_UNKNOWN_FILE_EXTENSION%60%2C%20causing%20%60check%3Aengine%60%20to%20fail%20before%20these%20assertions%20run.%0A%0A%23%23%23%20Issue%202%0Aweb%2Fsrc%2Flib%2Fwarp%2FdeviceName.ts%3A43-49%0A**Friendly%20names%20remain%20collision-ambiguous**%0A%0ATwo%20peers%20whose%20IDs%20map%20to%20the%20same%20one%20of%2057%2C600%20labels%20receive%20identical%20names%20with%20no%20room-level%20disambiguation%2C%20leaving%20device%20chips%2C%20incoming-offer%20attribution%2C%20and%20transfer-row%20labels%20unable%20to%20distinguish%20those%20devices.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ishannaik%2Fwarp&pr=324&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Aweb%2Fsrc%2Flib%2Fwarp%2FdeviceName.check.mjs%3A4%0A**Direct%20TypeScript%20import%20breaks%20checks**%0A%0AWhen%20this%20harness%20runs%20on%20Node%2022.6%E2%80%9322.17%2C%20which%20satisfies%20the%20repository's%20Node%20%3E%3D22%20requirement%2C%20the%20direct%20%60.%2FdeviceName.ts%60%20import%20is%20rejected%20with%20%60ERR_UNKNOWN_FILE_EXTENSION%60%2C%20causing%20%60check%3Aengine%60%20to%20fail%20before%20these%20assertions%20run.%0A%0A%23%23%23%20Issue%202%0Aweb%2Fsrc%2Flib%2Fwarp%2FdeviceName.ts%3A43-49%0A**Friendly%20names%20remain%20collision-ambiguous**%0A%0ATwo%20peers%20whose%20IDs%20map%20to%20the%20same%20one%20of%2057%2C600%20labels%20receive%20identical%20names%20with%20no%20room-level%20disambiguation%2C%20leaving%20device%20chips%2C%20incoming-offer%20attribution%2C%20and%20transfer-row%20labels%20unable%20to%20distinguish%20those%20devices.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=324&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/lib/warp/deviceName.check.mjs:4
**Direct TypeScript import breaks checks**

When this harness runs on Node 22.6–22.17, which satisfies the repository's Node >=22 requirement, the direct `./deviceName.ts` import is rejected with `ERR_UNKNOWN_FILE_EXTENSION`, causing `check:engine` to fail before these assertions run.

### Issue 2
web/src/lib/warp/deviceName.ts:43-49
**Friendly names remain collision-ambiguous**

Two peers whose IDs map to the same one of 57,600 labels receive identical names with no room-level disambiguation, leaving device chips, incoming-offer attribution, and transfer-row labels unable to distinguish those devices.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(#32,#26): structured NAT-failure pa..."](https://github.com/ishannaik/warp/commit/8d7a31465589ce5c819865a30c6ad2dd6ce5ecb2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55838486)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Web transfer UI orchestration](https://app.greptile.com/ishannaik/-/custom-context/knowledge-base/ishannaik/warp/-/docs/web-transfer-ui.md)
- Knowledge Base — [Theory page: explaining Warp's network path](https://app.greptile.com/ishannaik/-/custom-context/knowledge-base/ishannaik/warp/-/docs/web-theory.md)

<!-- /greptile_comment -->