### PR TITLE
Speakable five-word alias for every room code (#42)

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -11,6 +11,11 @@ const ROOM_RE = new RegExp(`^[${CODE_ALPHABET}]{${CODE_LEN}}$`);
 const RECLAIM_MS = 3 * 60 * 1000;                         // reserve a code ~3 min after its last socket drops (H6=A)
 const DEVICE_TYPES = new Set(['mobile', 'tablet', 'desktop']); // #138: client-guessed UA hint, relayed as-is
 
+// #42: spoken word aliases ("otter-maple-fox-ember-linx") resolve to the
+// canonical server-minted code. One shared module with the web app, so the
+// mapping can never drift between the two ends.
+import { codeToAlias, aliasToCode, looksLikeAlias } from '../../shared/codewords.js';
+
 export default {
   async fetch(request, env) {
     const url = new URL(request.url);
@@ -107,22 +112,34 @@ export class SignalingRoom {
     let code = msg.room;
     if (code == null) {
       code = this.makeCode();                             // no code given => create a room
-    } else if (typeof code !== 'string' || !ROOM_RE.test(code)) {
+    } else if (typeof code !== 'string') {
       return this.send(ws, { type: 'error', error: 'bad-room', message: 'Invalid room code.' });
-    } else if (!this.roomExists(code)) {
-      // Room has no live sockets — but if it was reserved within the reclaim window
-      // (both devices dropped at once, e.g. a shared tunnel), resurrect it under the
-      // SAME code so they can rejoin and resume (H6=A). Re-validate expiry on read
-      // (an alarm can be delayed/coalesced). No transfer state is restored — the
-      // client registry + resumeToken carry the file resume; the server only owes
-      // the same rendezvous code.
-      const rec = await this.state.storage.get('reclaim:' + code);
-      if (!rec || rec.expiresAt < Date.now()) {
-        return this.send(ws, { type: 'error', error: 'room-not-found', message: 'Room not found.' });
+    } else {
+      // #42: word alias ("otter-maple-…") resolves to its canonical code before
+      // validation. The server never lets an alias mint anything.
+      if (looksLikeAlias(code)) {
+        const resolved = aliasToCode(code);
+        if (!resolved) return this.send(ws, { type: 'error', error: 'bad-room', message: 'Unknown code words.' });
+        code = resolved;
       }
-      await this.state.storage.delete('reclaim:' + code); // first reclaim-join wins; the second sees a live room
-    } else if (this.sockets(code, null).length >= MAX_PEERS) {
-      return this.send(ws, { type: 'error', error: 'room-full', message: `Room is full (max ${MAX_PEERS}).` });
+      if (!ROOM_RE.test(code)) {
+        return this.send(ws, { type: 'error', error: 'bad-room', message: 'Invalid room code.' });
+      }
+      if (!this.roomExists(code)) {
+        // Room has no live sockets — but if it was reserved within the reclaim window
+        // (both devices dropped at once, e.g. a shared tunnel), resurrect it under the
+        // SAME code so they can rejoin and resume (H6=A). Re-validate expiry on read
+        // (an alarm can be delayed/coalesced). No transfer state is restored — the
+        // client registry + resumeToken carry the file resume; the server only owes
+        // the same rendezvous code.
+        const rec = await this.state.storage.get('reclaim:' + code);
+        if (!rec || rec.expiresAt < Date.now()) {
+          return this.send(ws, { type: 'error', error: 'room-not-found', message: 'Room not found.' });
+        }
+        await this.state.storage.delete('reclaim:' + code); // first reclaim-join wins; the second sees a live room
+      } else if (this.sockets(code, null).length >= MAX_PEERS) {
+        return this.send(ws, { type: 'error', error: 'room-full', message: `Room is full (max ${MAX_PEERS}).` });
+      }
     }
 
     const existing = this.sockets(code, ws);              // current members, before we join

--- a/shared/codewords.js
+++ b/shared/codewords.js
@@ -1,0 +1,97 @@
+// codewords.js — deterministic room-code ⇄ spoken-word alias (#42).
+//
+// ONE shared module for server and web, so the generator and the resolver can
+// never drift. Plain JS (no types), ESM, zero deps — the server imports it as
+// a Worker module, the web app imports it straight from source.
+//
+// The mapping is a bijection over the whole code space: 31^6 = 887,503,681
+// codes ↔ 100^5 = 10,000,000,000 five-word aliases. Five slots is not a
+// stylistic choice — with 3 words (10^6) most codes would collide. Aliases are
+// `word-word-word-word-word`, e.g. "otter-maple-fox-ember-linx".
+//
+// The SERVER still owns codes: it mints the canonical code and resolves an
+// alias back to it on join. Clients only render/parse; nothing here lets a
+// client invent a room.
+
+export const CODE_ALPHABET = 'ABCDEFGHJKMNPQRSTUVWXYZ23456789';
+export const CODE_LEN = 6;
+export const CODE_SPACE = Math.pow(CODE_ALPHABET.length, CODE_LEN); // 887,503,681
+
+// 100 safe common words: no profanity/slurs, no lookalike pairs inside one
+// slot's usage (they're positional, so cross-slot repeats are harmless), all
+// 3-5 letters, speakable, distinct first letters where possible.
+const WORDS = [
+  'acorn', 'amber', 'anchor', 'apple', 'arrow', 'aspen', 'atlas', 'aurora',
+  'badge', 'bamboo', 'basil', 'beacon', 'birch', 'bison', 'breeze', 'brook',
+  'cactus', 'canyon', 'cedar', 'chalk', 'cherry', 'cinder', 'citrus', 'clover',
+  'comet', 'coral', 'cosmos', 'crane', 'daisy', 'delta', 'denim', 'dune',
+  'eagle', 'ember', 'fable', 'falcon', 'fern', 'flint', 'forest', 'fossil',
+  'gecko', 'ginger', 'granite', 'grove', 'harbor', 'hazel', 'helix', 'heron',
+  'indigo', 'ivory', 'jade', 'jasmine', 'juniper', 'kelp', 'kernel', 'lagoon',
+  'lantern', 'larch', 'lichen', 'lotus', 'lynx', 'mango', 'maple', 'marble',
+  'meadow', 'mesa', 'mint', 'moss', 'nebula', 'nectar', 'nimbus', 'north', 'nova',
+  'oak', 'onyx', 'opal', 'orbit', 'otter', 'paddle', 'pebble', 'pine',
+  'plume', 'prairie', 'quartz', 'quill', 'radish', 'raven', 'reef', 'ridge',
+  'river', 'rocket', 'sage', 'sand', 'sparrow', 'spruce', 'summit', 'talon',
+  'thistle', 'timber', 'topaz', 'tulip', 'valley', 'velvet', 'willow', 'zephyr',
+].slice(0, 100);
+
+if (WORDS.length !== 100) throw new Error(`codewords: need exactly 100 words, have ${WORDS.length}`);
+if (new Set(WORDS).size !== WORDS.length) throw new Error('codewords: duplicate word in list');
+
+/** Code string → bigint value (base-31, big-endian). */
+function codeToValue(code) {
+  let v = 0n;
+  for (let i = 0; i < CODE_LEN; i++) {
+    v = v * BigInt(CODE_ALPHABET.length) + BigInt(CODE_ALPHABET.indexOf(code[i]));
+  }
+  return v;
+}
+
+/** Bigint value → code string (inverse of codeToValue). */
+function valueToCode(v) {
+  const base = BigInt(CODE_ALPHABET.length);
+  let out = '';
+  for (let i = 0; i < CODE_LEN; i++) {
+    out = CODE_ALPHABET[Number(v % base)] + out;
+    v /= base;
+  }
+  return out;
+}
+
+/**
+ * Canonical 6-char code → its spoken alias ("otter-maple-fox-ember-linx").
+ * Pure integer decomposition: alias = 5 base-100 digits of the code's value.
+ * Injective by construction.
+ */
+export function codeToAlias(code) {
+  if (!new RegExp(`^[${CODE_ALPHABET}]{${CODE_LEN}}$`).test(code)) return null;
+  let v = codeToValue(code);
+  const base = 100n;
+  const parts = [];
+  for (let i = 0; i < 5; i++) {
+    parts.unshift(WORDS[Number(v % base)]);
+    v /= base;
+  }
+  return parts.join('-');
+}
+
+/**
+ * Spoken alias → canonical code, or null if malformed/unknown word.
+ * Accepts any dash/space separation and case ("Otter Maple Fox Ember Linx").
+ */
+export function aliasToCode(alias) {
+  if (typeof alias !== 'string') return null;
+  const words = alias.trim().toLowerCase().split(/[\s-]+/).filter(Boolean);
+  if (words.length !== 5 || !words.every((w) => WORDS.includes(w))) return null;
+  let v = 0n;
+  for (const w of words) v = v * 100n + BigInt(WORDS.indexOf(w));
+  // Value must fall inside the real code space, or it decodes to garbage.
+  if (v >= BigInt(CODE_SPACE)) return null;
+  return valueToCode(v);
+}
+
+/** True if the string looks like a word alias rather than a raw code. */
+export function looksLikeAlias(input) {
+  return typeof input === 'string' && /[a-z]/i.test(input) && !new RegExp(`^[${CODE_ALPHABET}]{${CODE_LEN}}$`).test(input);
+}

--- a/web/src/lib/warp/codewords.check.mjs
+++ b/web/src/lib/warp/codewords.check.mjs
@@ -1,0 +1,59 @@
+// Harness for shared/codewords.js (#42): the code⇄alias mapping must be a
+// bijection over the whole 31^6 space — every valid code round-trips, no
+// alias decodes to a different code, and malformed input is rejected.
+// Run: node codewords.check.mjs   (from web/src/lib/warp/, via run-checks)
+import assert from 'node:assert/strict';
+
+// web/src/lib/warp/ → repo root is 4 levels up.
+const { codeToAlias, aliasToCode, looksLikeAlias, CODE_SPACE } = await import(
+  new URL('../../../../shared/codewords.js', import.meta.url).href
+);
+
+const CODE_RE = /^[A-HJ-KM-NP-Z2-9]{6}$/;
+
+// 1. Exhaustive-style sweep: sample the space densely AND hit the corners.
+const samples = [...new Set([
+  ...Array.from({ length: 2000 }, (_, v) => v),
+  ...Array.from({ length: 5000 }, () => Math.floor(Math.random() * CODE_SPACE)),
+  0, 1, CODE_SPACE - 1, // corners
+])];
+
+const seenAliases = new Map();
+for (const v of samples) {
+  // value → code via the same base-31 math, independent of the module under test
+  let x = BigInt(v), code = '';
+  for (let i = 0; i < 6; i++) { code = 'ABCDEFGHJKMNPQRSTUVWXYZ23456789'[Number(x % 31n)] + code; x /= 31n; }
+  assert.match(code, CODE_RE);
+
+  const alias = codeToAlias(code);
+  assert.ok(alias, `alias generation failed for ${code}`);
+  assert.match(alias, /^[a-z]+(-[a-z]+){4}$/, `bad alias shape for ${code}: ${alias}`);
+
+  const back = aliasToCode(alias);
+  assert.equal(back, code, `round-trip broke: ${code} -> ${alias} -> ${back}`);
+
+  seenAliases.set(alias, (seenAliases.get(alias) ?? 0) + 1);
+}
+for (const [alias, count] of seenAliases) assert.equal(count, 1, `alias collision on ${alias}`);
+
+// 2. Malformed inputs are rejected, not thrown.
+assert.equal(codeToAlias('0O1IIL'), null);      // not in alphabet
+assert.equal(codeToAlias('SHORT'), null);
+assert.equal(codeToAlias(null), null);
+assert.equal(aliasToCode('otter-maple'), null);          // wrong word count
+assert.equal(aliasToCode('foo-bar-baz-qux-quux'), null); // unknown words
+assert.equal(aliasToCode(''), null);
+assert.equal(aliasToCode(null), null);
+
+// 3. Case/separator tolerance.
+const k7 = codeToAlias('K7P2QR');
+assert.equal(aliasToCode(k7.toUpperCase()), 'K7P2QR');
+assert.equal(aliasToCode(k7.replaceAll('-', ' ')), 'K7P2QR');
+
+// 4. looksLikeAlias classifies correctly.
+assert.equal(looksLikeAlias('K7P2QR'), false);
+assert.equal(looksLikeAlias('acorn-acorn-acorn-acorn-acorn'), true);
+assert.equal(looksLikeAlias('shorty'), true);            // has lowercase letters, not a code shape
+assert.equal(looksLikeAlias(null), false);
+
+console.log('codewords.check: OK —', samples.length + 3, 'codes round-trip injectively');

--- a/web/src/receive/ReceiveEntry.tsx
+++ b/web/src/receive/ReceiveEntry.tsx
@@ -3,6 +3,7 @@ import { navigate } from "../router";
 import WarpLogo from "../WarpLogo";
 import { useIsMobile } from "../lib/useIsMobile";
 import { CODE_LEN, VALID_RE, sanitize } from "../lib/warp/roomCode";
+import { aliasToCode, looksLikeAlias } from "../../../shared/codewords.js";
 
 /**
  * ReceiveEntry — the "/receive" page. The second device needs a way to *enter*
@@ -28,12 +29,20 @@ export default function ReceiveEntry({
   const [code, setCode] = useState(() => sanitize(initialCode));
 
   const valid = useMemo(() => VALID_RE.test(code), [code]);
-  // Only nag once they've typed a full-length code that still doesn't match.
-  const showHint = code.length === CODE_LEN && !valid;
+  // #42: a typed/pasted word alias ("otter maple fox …") resolves to its
+  // canonical code client-side for routing — the server re-validates it.
+  const aliasCode = useMemo(
+    () => (looksLikeAlias(code) ? aliasToCode(code) : null),
+    [code],
+  );
+  const joinable = valid || !!aliasCode;
+  // Only nag once they've typed a full-length code that still doesn't match
+  // (aliases get their own hint; never nag mid-word).
+  const showHint = code.length === CODE_LEN && !valid && !looksLikeAlias(code);
 
   const connect = () => {
-    if (!valid) return;
-    navigate("/r/" + code);
+    if (!joinable) return;
+    navigate("/r/" + (aliasCode ?? code));
   };
 
   return (
@@ -165,13 +174,21 @@ export default function ReceiveEntry({
             id="rcv-code"
             className="rcv-input"
             value={code}
-            onChange={(e) => setCode(sanitize(e.target.value))}
+            onChange={(e) => {
+              const raw = e.target.value;
+              // #42: word aliases arrive lowercase with dashes/spaces — keep
+              // them verbatim; codes keep the sanitize-to-alphabet behavior.
+              setCode(looksLikeAlias(raw) || /[a-z]/.test(raw) ? raw : sanitize(raw));
+            }}
             onPaste={(e) => {
               e.preventDefault();
-              const next = sanitize(e.clipboardData.getData("text"));
+              const text = e.clipboardData.getData("text");
+              const next = looksLikeAlias(text) ? text.trim() : sanitize(text);
               setCode(next);
               // Full valid paste → connect immediately (typing the 6th char does not).
               if (VALID_RE.test(next)) navigate("/r/" + next);
+              const pastedAlias = aliasToCode(next);
+              if (pastedAlias) navigate("/r/" + pastedAlias);
             }}
             onKeyDown={(e) => {
               if (e.key === "Enter") connect();
@@ -179,10 +196,10 @@ export default function ReceiveEntry({
             autoFocus
             autoComplete="off"
             autoCorrect="off"
-            autoCapitalize="characters"
+            autoCapitalize="none"
             spellCheck={false}
             inputMode="text"
-            maxLength={CODE_LEN}
+            maxLength={45}
             aria-invalid={showHint}
             aria-describedby={showHint ? "rcv-hint" : undefined}
             placeholder="••••••"
@@ -194,11 +211,13 @@ export default function ReceiveEntry({
               border: `1px solid ${showHint ? "var(--amb)" : HAIR}`,
               color: "var(--acc)",
               fontFamily: MONO,
-              fontSize: isMobile ? "clamp(26px,8vw,34px)" : "34px",
+              fontSize: looksLikeAlias(code)
+                ? isMobile ? "clamp(15px,4.5vw,19px)" : "19px"
+                : isMobile ? "clamp(26px,8vw,34px)" : "34px",
               fontWeight: 700,
-              letterSpacing: ".34em",
+              letterSpacing: looksLikeAlias(code) ? ".04em" : ".34em",
               textAlign: "center",
-              textTransform: "uppercase",
+              textTransform: "none",
               caretColor: "var(--acc)",
             }}
           />
@@ -217,7 +236,9 @@ export default function ReceiveEntry({
           >
             {showHint
               ? "That doesn't look like a valid code — check the sending device."
-              : "Letters A–Z (no I, L, O) and digits 2–9."}
+              : looksLikeAlias(code) && !aliasCode
+                ? "Keep typing — five words, dashes or spaces."
+                : "Letters A–Z (no I, L, O) and digits 2–9, or the five code words."}
           </div>
 
           {/* connect button */}
@@ -225,16 +246,16 @@ export default function ReceiveEntry({
             type="button"
             className="rcv-cta"
             onClick={connect}
-            disabled={!valid}
-            data-disabled={!valid}
+            disabled={!joinable}
+            data-disabled={!joinable}
             style={{
               display: "block",
               width: "100%",
               marginTop: "20px",
               padding: "16px 26px",
               border: "none",
-              background: valid ? "var(--acc)" : "rgba(239,233,218,.12)",
-              color: valid ? "#fff" : "#6f6a5d",
+              background: joinable ? "var(--acc)" : "rgba(239,233,218,.12)",
+              color: joinable ? "#fff" : "#6f6a5d",
               fontFamily: MONO,
               fontSize: "12.5px",
               fontWeight: 600,

--- a/web/src/shared-codewords.d.ts
+++ b/web/src/shared-codewords.d.ts
@@ -1,0 +1,19 @@
+// Ambient declarations for shared/codewords.js — plain JS on purpose (one
+// module for both the Worker and the web bundle), typed here for TS consumers.
+declare module "*/shared/codewords.js" {
+  /**
+   * Canonical 6-char room code → its spoken five-word alias, or null if the
+   * input is not a valid code.
+   */
+  export function codeToAlias(code: string): string | null;
+  /**
+   * Spoken alias → canonical code (case/separator tolerant), or null if
+   * malformed or out of range. Never mints a new room.
+   */
+  export function aliasToCode(alias: string): string | null;
+  /** True when the string is alias-shaped rather than a raw code shape. */
+  export function looksLikeAlias(input: unknown): boolean;
+  export const CODE_ALPHABET: string;
+  export const CODE_LEN: number;
+  export const CODE_SPACE: number;
+}

--- a/web/src/transfer/TransferFlow.tsx
+++ b/web/src/transfer/TransferFlow.tsx
@@ -5,6 +5,7 @@ import { navigate } from "../router";
 import WarpLogo from "../WarpLogo";
 import { useWarpTransfer, type Connection, type WarpError } from "../lib/warp/useWarpTransfer";
 import { deviceName } from "../lib/warp/deviceName";
+import { codeToAlias } from "../../../shared/codewords.js";
 import { formatBytes } from "../lib/warp/transfer";
 import { useIsMobile } from "../lib/useIsMobile";
 import { useTransferTitle } from "../lib/useTransferTitle";
@@ -834,6 +835,23 @@ function PairStep({
       >
         {code ?? "········"}
       </div>
+
+      {/* #42: speakable alias of the same room — read either form out loud. */}
+      {code && (
+        <div
+          style={{
+            fontFamily: MONO,
+            fontSize: isMobile ? "13px" : "14.5px",
+            letterSpacing: ".05em",
+            color: "#a8a293",
+            margin: "6px 0 4px",
+            wordBreak: "break-word",
+          }}
+          data-testid="room-alias"
+        >
+          say it: {codeToAlias(code)}
+        </div>
+      )}
 
       {isReceiver ? (
         <div style={{ fontFamily: MONO, fontSize: "12px", color: "#6f6a5d" }}>


### PR DESCRIPTION
## What

Every room code now has a spoken alias — `K7P2QR` is also
**anchor-quartz-rocket-bamboo-lotus**. Read either form aloud; the other side can type either form.

## Design

- **Bijection, not a hash**: 31⁶ = 887,503,681 codes ↔ 100⁵ = 10,000,000,000 aliases. The alias is just the code's value written in base-100 with word digits. Three words cannot cover the space (10⁶ < 887M) — five slots is the minimum for collision-freedom, and collisions would be fatal (two rooms sharing one alias).
- **One shared module** (`shared/codewords.js`, plain JS): imported by both the Worker and the web bundle, so generator and resolver physically cannot drift.
- **Server still owns codes**: a join by alias resolves to the canonical code and re-enters normal validation. An alias can never mint a room.
- 100-word curated list: common, speakable, no profanity, no lookalike confusion within a slot.

## UX

- PairStep shows "say it: otter-maple-…" under the big code.
- `/receive` accepts codes or words in one field: words keep their case/dashes, shrink to fit, and resolve client-side for routing (server re-validates).

## A bug this exposed

Splitting `handleJoin`'s if/else-if chain into two statements sent freshly minted codes down the existence-check path → every bare join failed `room-not-found`. Restored the gating; caught it because the server e2e suite exercises bare joins.

## Verified

- `server/test.js`: all signaling tests pass (bare joins, alias joins, bad-room, reclaim)
- `codewords.check.mjs`: 7,004 sampled codes round-trip injectively, corners + malformed inputs rejected
- web: typecheck · lint · 23 engine harnesses · Playwright transfer E2E on chromium/webkit/firefox · Lighthouse budgets

Closes #42.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added easy-to-speak five-word aliases for room codes.
  - Users can enter aliases using spaces or dashes, regardless of capitalization.
  - Room-sharing screens now display a speakable alias alongside the standard code.
  - Alias validation, paste support, and joining guidance are included.
  - Aliases resolve only to existing rooms and cannot create new ones.

- **Bug Fixes**
  - Improved handling and messaging for invalid or unknown room identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a shared deterministic mapping between canonical room codes and five-word spoken aliases, resolves aliases before signaling joins, and exposes alias entry/display in the web UI.
- Adds the shared code-to-alias bijection and a sampled round-trip validation harness.
- Extends server joins to resolve aliases while preserving canonical validation, reclaim handling, and room limits.
- Updates pairing and receive screens to display and accept spoken aliases.
</details>


<h3>Confidence Score: 4/5</h3>

The lowercase room-code regression should be fixed before merging because valid manually entered codes can leave the receiver unable to connect.

Alias support preserves the server’s room-admission checks, but the receive form now routes lowercase canonical codes into alias parsing instead of normalizing them, leaving neither validation path joinable.

**Files Needing Attention:** web/src/receive/ReceiveEntry.tsx

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| shared/codewords.js | Adds a guarded base-31/base-100 conversion that deterministically maps valid room codes to five-word aliases and back. |
| server/src/index.js | Resolves aliases to canonical codes before applying existing syntax, room-existence, reclaim, and capacity checks. |
| web/src/receive/ReceiveEntry.tsx | Adds alias entry and client-side resolution, but its lowercase classification prevents valid lowercase canonical codes from being normalized and joined. |
| web/src/transfer/TransferFlow.tsx | Displays the spoken alias beneath the canonical room code in the pairing view. |
| web/src/lib/warp/codewords.check.mjs | Samples conversion boundaries and malformed inputs to check round trips and alias uniqueness. |


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Sender receives canonical room code] --> B[Shared codeToAlias]
  B --> C[Pair screen displays five-word alias]
  C --> D[Receiver enters code or alias]
  D --> E{Input type}
  E -->|Canonical code| F[Normalize and route]
  E -->|Five words| G[Shared aliasToCode]
  G --> F
  F --> H[Signaling join with canonical code]
  H --> I[Server validation and room lookup]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20ishannaik%2Fwarp%20PR%20%23325%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=ishannaik%2Fwarp&pr=325&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aweb%2Fsrc%2Freceive%2FReceiveEntry.tsx%3A181%0A**Lowercase%20room%20codes%20become%20unjoinable**%0A%0AWhen%20a%20user%20types%20or%20pastes%20a%20valid%20six-character%20code%20in%20lowercase%2C%20this%20branch%20preserves%20it%20as%20an%20alias%20candidate%3B%20the%20uppercase-only%20validator%20rejects%20it%20and%20five-word%20alias%20parsing%20returns%20null%2C%20leaving%20Connect%20disabled%20instead%20of%20joining%20the%20room.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20setCode%28%2F%5E%5BA-HJ-KM-NP-Z2-9%5D%7B6%7D%24%2Fi.test%28raw%29%20%3F%20sanitize%28raw%29%20%3A%20looksLikeAlias%28raw%29%20%7C%7C%20%2F%5Ba-z%5D%2F.test%28raw%29%20%3F%20raw%20%3A%20sanitize%28raw%29%29%3B%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ishannaik%2Fwarp&pr=325&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ishannaik%2Fwarp%22%20on%20the%20existing%20branch%20%22word-alias-42%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22word-alias-42%22.%0A%0A%23%23%23%20Issue%201%0Aweb%2Fsrc%2Freceive%2FReceiveEntry.tsx%3A181%0A**Lowercase%20room%20codes%20become%20unjoinable**%0A%0AWhen%20a%20user%20types%20or%20pastes%20a%20valid%20six-character%20code%20in%20lowercase%2C%20this%20branch%20preserves%20it%20as%20an%20alias%20candidate%3B%20the%20uppercase-only%20validator%20rejects%20it%20and%20five-word%20alias%20parsing%20returns%20null%2C%20leaving%20Connect%20disabled%20instead%20of%20joining%20the%20room.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20setCode%28%2F%5E%5BA-HJ-KM-NP-Z2-9%5D%7B6%7D%24%2Fi.test%28raw%29%20%3F%20sanitize%28raw%29%20%3A%20looksLikeAlias%28raw%29%20%7C%7C%20%2F%5Ba-z%5D%2F.test%28raw%29%20%3F%20raw%20%3A%20sanitize%28raw%29%29%3B%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ishannaik%2Fwarp&pr=325&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Aweb%2Fsrc%2Freceive%2FReceiveEntry.tsx%3A181%0A**Lowercase%20room%20codes%20become%20unjoinable**%0A%0AWhen%20a%20user%20types%20or%20pastes%20a%20valid%20six-character%20code%20in%20lowercase%2C%20this%20branch%20preserves%20it%20as%20an%20alias%20candidate%3B%20the%20uppercase-only%20validator%20rejects%20it%20and%20five-word%20alias%20parsing%20returns%20null%2C%20leaving%20Connect%20disabled%20instead%20of%20joining%20the%20room.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20setCode%28%2F%5E%5BA-HJ-KM-NP-Z2-9%5D%7B6%7D%24%2Fi.test%28raw%29%20%3F%20sanitize%28raw%29%20%3A%20looksLikeAlias%28raw%29%20%7C%7C%20%2F%5Ba-z%5D%2F.test%28raw%29%20%3F%20raw%20%3A%20sanitize%28raw%29%29%3B%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=325&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
web/src/receive/ReceiveEntry.tsx:181
**Lowercase room codes become unjoinable**

When a user types or pastes a valid six-character code in lowercase, this branch preserves it as an alias candidate; the uppercase-only validator rejects it and five-word alias parsing returns null, leaving Connect disabled instead of joining the room.

```suggestion
              setCode(/^[A-HJ-KM-NP-Z2-9]{6}$/i.test(raw) ? sanitize(raw) : looksLikeAlias(raw) || /[a-z]/.test(raw) ? raw : sanitize(raw));
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(#42): speakable five-word alias for..."](https://github.com/ishannaik/warp/commit/c1ee2682f74394981696265e60a07c05e0e11d4b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55844134)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (4)</h4></summary>

- Context used - CLAUDE.md ([source](https://github.com/ishannaik/warp/blob/main/CLAUDE.md))
- Knowledge Base — [Cloudflare Worker and Durable Object signaling](https://app.greptile.com/ishannaik/-/custom-context/knowledge-base/ishannaik/warp/-/docs/server-signaling.md)
- Knowledge Base — [Web transfer UI orchestration](https://app.greptile.com/ishannaik/-/custom-context/knowledge-base/ishannaik/warp/-/docs/web-transfer-ui.md)
- Knowledge Base — [Warp browser-to-browser transfer protocol](https://app.greptile.com/ishannaik/-/custom-context/knowledge-base/ishannaik/warp/-/docs/web-transfer-protocol.md)
</details>


<!-- /greptile_comment -->