### PR TITLE
fix(a11y): label cloud versus direct diagram

### DIFF
--- a/web/src/theory/diagrams/CloudVsDirect.tsx
+++ b/web/src/theory/diagrams/CloudVsDirect.tsx
@@ -74,6 +74,8 @@ export default function CloudVsDirect() {
   return (
     <DiagramFrame caption="FIG 01 · CLOUD VS DIRECT" tone="amb">
       <div
+        role="img"
+        aria-label="Cloud transfer makes two hops and leaves a stored copy; direct peer-to-peer transfer makes one hop and retains no copy."
         style={{
           display: "grid",
           // Phones: stack the CLOUD and DIRECT panels so each gets full width.


### PR DESCRIPTION
## What & why

Give the cloud-versus-direct comparison a concise accessible name so screen-reader users receive the same transfer-path and retention contrast as sighted users.

Closes #321

## Type

- [ ] feat
- [x] fix
- [ ] docs / chore / refactor / test / perf

## Checklist

- [x] `pnpm lint && pnpm typecheck` pass locally
- [x] `pnpm --filter @warp/web build` is green (web changes)
- [x] UI checked at **~360–430px width** — no horizontal overflow, existing `useNarrowViewport()` mobile branch present
- [x] Design tokens + inline-style component style respected (no drive-by restyling)

### Hard constraints (see [CONTRIBUTING.md](../CONTRIBUTING.md#hard-constraints-the-soul-of-the-project))

- [x] No new recurring-cost infrastructure — no TURN, database, storage, or paid API ($0, no card, forever)
- [x] Still STUN-only — no relay in the file path; NAT failure stays an honest error
- [x] The signaling server still never reads, stores, or understands file contents
- [x] `SEND_HIGH_WATER` in `peer.ts` untouched or still well below 16 MiB
- [x] Transient network drops still recover (no new terminal errors for blips; keepalive ping intact)

## Screenshots / recordings

This is an accessibility-tree-only change with no visual delta. I rendered and inspected the diagram at 1440×1000 and 390×844; the desktop split and phone stack remain intact, and the phone page has no horizontal overflow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved screen reader support for the Cloud vs. Direct comparison diagram with a descriptive label explaining both transfer methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds an accessible name to the cloud-versus-direct comparison so assistive technologies receive the diagram’s essential meaning.
- Marks the comparison grid as an image.
- Describes the cloud path’s two hops and stored copy versus the direct path’s one hop and lack of retention.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The static accessible name accurately captures the diagram’s central comparison, and the labeled subtree contains no interactive controls whose operation would be lost.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| web/src/theory/diagrams/CloudVsDirect.tsx | Adds accurate image semantics and a concise text alternative without changing visual layout, animation, or transfer behavior. |

<sub>Reviews (1): Last reviewed commit: ["fix(a11y): label cloud versus direct dia..."](https://github.com/ishannaik/warp/commit/7f30d50c40808828ece3a23ca5b238988f82955f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55984029)</sub>

**Context used:**

- Knowledge Base — [Protocol education experience](https://app.greptile.com/ishannaik/-/custom-context/knowledge-base/ishannaik/warp/-/docs/protocol-education-experience.md)

<!-- /greptile_comment -->