### PR TITLE
fix(a11y): label chunking diagram

### DIFF
--- a/web/src/theory/diagrams/Chunking.tsx
+++ b/web/src/theory/diagrams/Chunking.tsx
@@ -92,6 +92,8 @@ export default function Chunking() {
         tone={valveOpen ? "acc" : "amb"}
       >
         <div
+          role="img"
+          aria-label="A 4.2 GB file is sliced into 16 KB chunks and streamed to Peer B, which reassembles them; buffer high- and low-water marks pause and resume sending so memory stays flat."
           style={{
             display: "flex",
             alignItems: "stretch",


### PR DESCRIPTION
## What & why

Give the chunking diagram an accessible name so screen readers can describe the 16 KB slice + backpressure animation. No visual change.

Closes #320

## Type

- [ ] feat
- [x] fix
- [ ] docs / chore / refactor / test / perf

## Checklist

- [x] `pnpm lint && pnpm typecheck` pass locally
- [x] `pnpm --filter @warp/web build` is green (web changes)
- [x] UI checked at **~360–430px width** — no horizontal overflow, mobile branch present (`useIsMobile()`)
- [x] Design tokens + inline-style component style respected (no drive-by restyling)

### Hard constraints (see [CONTRIBUTING.md](../CONTRIBUTING.md#hard-constraints-the-soul-of-the-project))

- [x] No new recurring-cost infrastructure — no TURN, database, storage, or paid API ($0, no card, forever)
- [x] Still STUN-only — no relay in the file path; NAT failure stays an honest error
- [x] The signaling server still never reads, stores, or understands file contents
- [x] `SEND_HIGH_WATER` in `peer.ts` untouched or still well below 16 MiB
- [x] Transient network drops still recover (no new terminal errors for blips; keepalive ping intact)

## Screenshots / recordings

390×844 `/how` FIG 05: diagram scales to fit; `scrollWidth === clientWidth === 390`; no horizontal overflow. Accessible name is the `aria-label` on the inner `role="img"` div (same placement as #326 in `CloudVsDirect.tsx`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Accessibility**
  - Improved screen reader support for the file-chunking diagram by identifying it as an image and adding a descriptive label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->