### PR TITLE
refactor: centralize blob download helper

### DIFF
--- a/web/src/lib/saveBlob.ts
+++ b/web/src/lib/saveBlob.ts
@@ -1,0 +1,12 @@
+/** Trigger a browser download of a blob via a transient object-URL anchor. */
+export function saveBlob(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  // Revoke after the click has had time to start the download.
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+}

--- a/web/src/lib/warp/useWarpTransfer.ts
+++ b/web/src/lib/warp/useWarpTransfer.ts
@@ -27,6 +27,7 @@
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { saveBlob } from "../saveBlob";
 import { SignalingClient, type SignalData } from "./signaling";
 import { deviceName } from "./deviceName";
 import {
@@ -267,19 +268,6 @@ async function uniqueName(used: Set<string>, name: string, dir?: FsDirHandle): P
     }
     candidate = `${stem} (${n})${ext}`;
   }
-}
-
-/** Trigger a browser download of a blob via a transient object-URL anchor. */
-function saveBlob(blob: Blob, filename: string): void {
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement("a");
-  a.href = url;
-  a.download = filename;
-  document.body.appendChild(a);
-  a.click();
-  a.remove();
-  // Revoke on the next tick so the click has time to start the download.
-  setTimeout(() => URL.revokeObjectURL(url), 1000);
 }
 
 export function useWarpTransfer(joinCode?: string): UseWarpTransfer {

--- a/web/src/lib/warp/zipDownload.ts
+++ b/web/src/lib/warp/zipDownload.ts
@@ -23,6 +23,7 @@
  */
 
 import { Zip, ZipPassThrough } from "fflate";
+import { saveBlob } from "../saveBlob";
 
 /** One received file to pack: its (de-duped downstream) name and in-memory blob. */
 export interface ZipEntry {
@@ -48,19 +49,6 @@ function uniqueName(used: Set<string>, name: string): string {
   const out = `${stem} (${n})${ext}`;
   used.add(out);
   return out;
-}
-
-/** Trigger a browser download of a blob via a transient object-URL anchor. */
-function saveBlob(blob: Blob, filename: string): void {
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement("a");
-  a.href = url;
-  a.download = filename;
-  document.body.appendChild(a);
-  a.click();
-  a.remove();
-  // Revoke on the next tick so the click has time to start the download.
-  setTimeout(() => URL.revokeObjectURL(url), 1000);
 }
 
 /**

--- a/web/src/nearby/useNearbyTransfer.ts
+++ b/web/src/nearby/useNearbyTransfer.ts
@@ -22,6 +22,7 @@
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { saveBlob } from "../lib/saveBlob";
 import { useNearby, type IncomingConnection, type NearbyDevice } from "../lib/warp/useNearby";
 import type { WarpPeer } from "../lib/warp/peer";
 import { streamZipDownload } from "../lib/warp/zipDownload";
@@ -75,18 +76,6 @@ const PEER_ERROR_COPY: Record<string, string> = {
   disconnected: "The other device disconnected before the transfer finished.",
   "channel-error": "The direct link to the other device broke.",
 };
-
-/** Trigger a browser download of a blob via a transient object-URL anchor. */
-function saveBlob(blob: Blob, filename: string): void {
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement("a");
-  a.href = url;
-  a.download = filename;
-  document.body.appendChild(a);
-  a.click();
-  a.remove();
-  setTimeout(() => URL.revokeObjectURL(url), 1000);
-}
 
 export function useNearbyTransfer(): UseNearbyTransfer {
   const nearby = useNearby();

--- a/web/src/transfer/SessionView.tsx
+++ b/web/src/transfer/SessionView.tsx
@@ -27,6 +27,7 @@ import {
   type TransferItem,
 } from "../lib/warp/transfer";
 import { copyToClipboard } from "../lib/copyToClipboard";
+import { saveBlob } from "../lib/saveBlob";
 import type { Connection, TransferStats } from "../lib/warp/useWarpTransfer";
 import { deviceName } from "../lib/warp/deviceName";
 import { formatDuration, formatSpeed } from "../lib/warp/transferStats";
@@ -54,20 +55,6 @@ function typeGlyph(mime: string, kind: TransferItem["kind"]): string {
 /** Aggregate size label for a manifest. */
 function totalBytes(items: { size: number }[]): number {
   return items.reduce((s, i) => s + i.size, 0);
-}
-
-/** Trigger a browser download of a blob via a transient object-URL anchor
- *  (same small helper duplicated per-file elsewhere — useWarpTransfer.ts,
- *  useNearbyTransfer.ts, zipDownload.ts — rather than shared). */
-function saveBlob(blob: Blob, filename: string): void {
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement("a");
-  a.href = url;
-  a.download = filename;
-  document.body.appendChild(a);
-  a.click();
-  a.remove();
-  setTimeout(() => URL.revokeObjectURL(url), 1000);
 }
 
 /* ----------------------------------------------------------------- thumbnail */


### PR DESCRIPTION
## What & why

Centralize the repeated transient-anchor Blob download helper in `web/src/lib/saveBlob.ts` and reuse it from every current call site.

Issue #313 originally calls out the duplicate in `useWarpTransfer.ts` and `useNearbyTransfer.ts`. On current `main`, the same helper also exists in `SessionView.tsx` and `zipDownload.ts`, so this PR consolidates all four copies rather than leaving two duplicate implementations behind. This also makes the issue's verification condition true: `function saveBlob` has one implementation.

Behavior is intentionally unchanged:

- create one object URL
- create/append a transient `<a download>`
- click and remove it
- revoke the object URL after 1000 ms

`zipDownload.check.mjs` continues to exercise the anchor-download integration through the ZIP path, now via the shared helper.

Closes #313

## Type

- [ ] feat
- [ ] fix
- [x] docs / chore / refactor / test / perf

## Checklist

- [x] GitHub Actions: web lint + typecheck are green
- [x] GitHub Actions: `pnpm --filter @warp/web build` is green
- [x] GitHub Actions: `pnpm --filter @warp/web check:engine` is green
- [x] GitHub Actions: Chromium + WebKit + advisory Firefox transfer E2E are green
- [x] GitHub Actions: Lighthouse and dependency audit are green
- [x] No UI/layout change; mobile-width check not applicable
- [x] No design-token or component-style changes

The repository dependencies cannot be installed in this execution environment, so these checks are reported from the upstream GitHub Actions run rather than claimed as local execution.

### Hard constraints

- [x] No new dependencies or recurring-cost infrastructure
- [x] Still STUN-only; no transport changes
- [x] Signaling server untouched
- [x] `SEND_HIGH_WATER` untouched
- [x] Reconnect/resume behavior untouched

## Screenshots / recordings

Not applicable — behavior-preserving refactor with no visual change.
